### PR TITLE
smal fix for bug in SumOfInfeasibilitiesManager::proposePhasePatternU… -  - Merge idan0610's fork to solve regression tests failling due to fixed Sign Layer splitting (MarabouError 7).

### DIFF
--- a/src/engine/SumOfInfeasibilitiesManager.cpp
+++ b/src/engine/SumOfInfeasibilitiesManager.cpp
@@ -195,8 +195,19 @@ void SumOfInfeasibilitiesManager::proposePhasePatternUpdateRandomly()
     } );
 
     // First, pick a pl constraint whose cost component we will update.
-    unsigned index = (unsigned)T::rand() % _plConstraintsInCurrentPhasePattern.size();
-    PiecewiseLinearConstraint *plConstraintToUpdate = _plConstraintsInCurrentPhasePattern[index];
+    bool fixed = true;
+    PiecewiseLinearConstraint *plConstraintToUpdate;
+    while ( fixed )
+    {
+        if ( _plConstraintsInCurrentPhasePattern.empty() )
+            return;
+
+        unsigned index = (unsigned)T::rand() % _plConstraintsInCurrentPhasePattern.size();
+        plConstraintToUpdate = _plConstraintsInCurrentPhasePattern[index];
+        fixed = plConstraintToUpdate->phaseFixed();
+        if ( fixed )
+            removeCostComponentFromHeuristicCost( plConstraintToUpdate );
+    }
 
     // Next, pick an alternative phase.
     PhaseStatus currentPhase = _currentPhasePattern[plConstraintToUpdate];


### PR DESCRIPTION
…pdateRandomly() when the chosen plConstraintToUpdate is fixed