### PR TITLE
Manually Sync Fork + Apply Results of PMNR Optimization Benchmarks

### DIFF
--- a/src/configuration/GlobalConfiguration.cpp
+++ b/src/configuration/GlobalConfiguration.cpp
@@ -119,8 +119,8 @@ const bool GlobalConfiguration::WRITE_JSON_PROOF = false;
 const unsigned GlobalConfiguration::BACKWARD_BOUND_PROPAGATION_DEPTH = 3;
 const unsigned GlobalConfiguration::MAX_ROUNDS_OF_BACKWARD_ANALYSIS = 10;
 
-const bool GlobalConfiguration::ANALYZE_PROOF_DEPENDENCIES = false;
-const bool GlobalConfiguration::MINIMIZE_PROOF_DEPENDENCIES = false;
+const bool GlobalConfiguration::ANALYZE_PROOF_DEPENDENCIES = true;
+const bool GlobalConfiguration::MINIMIZE_PROOF_DEPENDENCIES = true;
 
 #ifdef ENABLE_GUROBI
 const unsigned GlobalConfiguration::GUROBI_NUMBER_OF_THREADS = 1;

--- a/src/configuration/GlobalConfiguration.cpp
+++ b/src/configuration/GlobalConfiguration.cpp
@@ -80,12 +80,11 @@ const unsigned GlobalConfiguration::INVPROP_MAX_ITERATIONS = 10;
 const double GlobalConfiguration::INVPROP_STEP_SIZE = 0.025;
 const double GlobalConfiguration::INVPROP_LEARNING_RATE = 0.005;
 const double GlobalConfiguration::INVPROP_WEIGHT_DECAY = 0.5;
-const double GlobalConfiguration::INVPROP_INITIAL_ALPHA = 0.5;
 const double GlobalConfiguration::INVPROP_INITIAL_GAMMA = 0.025;
 
 const unsigned GlobalConfiguration::PMNR_RANDOM_SEED = 1;
 const unsigned GlobalConfiguration::PMNR_SELECTED_NEURONS = 2;
-const unsigned GlobalConfiguration::PMNR_BBPS_BRANCHING_CANDIDATES = 10;
+const unsigned GlobalConfiguration::PMNR_BBPS_BRANCHING_CANDIDATES = 100;
 
 const bool GlobalConfiguration::USE_HARRIS_RATIO_TEST = true;
 
@@ -137,7 +136,7 @@ const bool GlobalConfiguration::WRITE_JSON_PROOF = false;
 
 const unsigned GlobalConfiguration::BACKWARD_BOUND_PROPAGATION_DEPTH = 3;
 const unsigned GlobalConfiguration::MAX_ROUNDS_OF_BACKWARD_ANALYSIS = 10;
-const unsigned GlobalConfiguration::MAX_ROUNDS_OF_PMNR_BACKWARD_ANALYSIS = 1;
+const unsigned GlobalConfiguration::MAX_ROUNDS_OF_PMNR_BACKWARD_ANALYSIS = 10;
 
 const bool GlobalConfiguration::ANALYZE_PROOF_DEPENDENCIES = false;
 const bool GlobalConfiguration::MINIMIZE_PROOF_DEPENDENCIES = false;

--- a/src/configuration/GlobalConfiguration.h
+++ b/src/configuration/GlobalConfiguration.h
@@ -184,9 +184,6 @@ public:
     // Weight decay for INVPROP optimization.
     static const double INVPROP_WEIGHT_DECAY;
 
-    // Initial alpha values for INVPROP optimization.
-    static const double INVPROP_INITIAL_ALPHA;
-
     // Initial gamma values for INVPROP optimization.
     static const double INVPROP_INITIAL_GAMMA;
 

--- a/src/configuration/OptionParser.cpp
+++ b/src/configuration/OptionParser.cpp
@@ -267,10 +267,8 @@ void OptionParser::initialize()
                 &( ( *_stringOptions )[Options::MILP_SOLVER_BOUND_TIGHTENING_TYPE] ) )
                 ->default_value( ( *_stringOptions )[Options::MILP_SOLVER_BOUND_TIGHTENING_TYPE] ),
             "The MILP solver bound tightening type: "
-            "lp/backward-once/backward-converge/backward-preimage-approx/backward-invprop/"
-            "backward-pmnr-random/"
-            "backward-pmnr-gradient/backward-pmnr-bbps/lp-inc/milp/milp-inc/"
-            "iter-prop/none." )
+            "lp/backward-once/backward-converge/backward-preimage-approx/backward-pmnr/lp-inc/milp/"
+            "milp-inc/iter-prop/none." )
 #endif
         ;
 

--- a/src/configuration/Options.cpp
+++ b/src/configuration/Options.cpp
@@ -211,14 +211,8 @@ MILPSolverBoundTighteningType Options::getMILPSolverBoundTighteningType() const
             return MILPSolverBoundTighteningType::BACKWARD_ANALYSIS_CONVERGE;
         if ( strategyString == "backward-preimage-approx" )
             return MILPSolverBoundTighteningType::BACKWARD_ANALYSIS_PREIMAGE_APPROX;
-        if ( strategyString == "backward-invprop" )
-            return MILPSolverBoundTighteningType::BACKWARD_ANALYSIS_INVPROP;
-        if ( strategyString == "backward-pmnr-random" )
-            return MILPSolverBoundTighteningType::BACKWARD_ANALYSIS_PMNR_RANDOM;
-        if ( strategyString == "backward-pmnr-gradient" )
-            return MILPSolverBoundTighteningType::BACKWARD_ANALYSIS_PMNR_GRADIENT;
-        if ( strategyString == "backward-pmnr-bbps" )
-            return MILPSolverBoundTighteningType::BACKWARD_ANALYSIS_PMNR_BBPS;
+        if ( strategyString == "backward-pmnr" )
+            return MILPSolverBoundTighteningType::BACKWARD_ANALYSIS_PMNR;
         else if ( strategyString == "milp" )
             return MILPSolverBoundTighteningType::MILP_ENCODING;
         else if ( strategyString == "milp-inc" )

--- a/src/engine/Engine.cpp
+++ b/src/engine/Engine.cpp
@@ -1598,10 +1598,7 @@ void Engine::performMILPSolverBoundedTightening( Query *inputQuery )
         case MILPSolverBoundTighteningType::BACKWARD_ANALYSIS_ONCE:
         case MILPSolverBoundTighteningType::BACKWARD_ANALYSIS_CONVERGE:
         case MILPSolverBoundTighteningType::BACKWARD_ANALYSIS_PREIMAGE_APPROX:
-        case MILPSolverBoundTighteningType::BACKWARD_ANALYSIS_INVPROP:
-        case MILPSolverBoundTighteningType::BACKWARD_ANALYSIS_PMNR_RANDOM:
-        case MILPSolverBoundTighteningType::BACKWARD_ANALYSIS_PMNR_GRADIENT:
-        case MILPSolverBoundTighteningType::BACKWARD_ANALYSIS_PMNR_BBPS:
+        case MILPSolverBoundTighteningType::BACKWARD_ANALYSIS_PMNR:
             _networkLevelReasoner->lpRelaxationPropagation();
             break;
         case MILPSolverBoundTighteningType::MILP_ENCODING:
@@ -1676,14 +1673,7 @@ void Engine::performAdditionalBackwardAnalysisIfNeeded()
             printf( "Backward analysis tightened %u bounds\n", tightened );
     }
 
-    if ( _milpSolverBoundTighteningType ==
-             MILPSolverBoundTighteningType::BACKWARD_ANALYSIS_INVPROP ||
-         _milpSolverBoundTighteningType ==
-             MILPSolverBoundTighteningType::BACKWARD_ANALYSIS_PMNR_RANDOM ||
-         _milpSolverBoundTighteningType ==
-             MILPSolverBoundTighteningType::BACKWARD_ANALYSIS_PMNR_GRADIENT ||
-         _milpSolverBoundTighteningType ==
-             MILPSolverBoundTighteningType::BACKWARD_ANALYSIS_PMNR_BBPS )
+    if ( _milpSolverBoundTighteningType == MILPSolverBoundTighteningType::BACKWARD_ANALYSIS_PMNR )
     {
         unsigned tightened = performSymbolicBoundTightening( &( *_preprocessedQuery ) );
         if ( _verbosity > 0 )
@@ -1724,10 +1714,7 @@ void Engine::performMILPSolverBoundedTighteningForSingleLayer( unsigned targetIn
         case MILPSolverBoundTighteningType::BACKWARD_ANALYSIS_ONCE:
         case MILPSolverBoundTighteningType::BACKWARD_ANALYSIS_CONVERGE:
         case MILPSolverBoundTighteningType::BACKWARD_ANALYSIS_PREIMAGE_APPROX:
-        case MILPSolverBoundTighteningType::BACKWARD_ANALYSIS_INVPROP:
-        case MILPSolverBoundTighteningType::BACKWARD_ANALYSIS_PMNR_RANDOM:
-        case MILPSolverBoundTighteningType::BACKWARD_ANALYSIS_PMNR_GRADIENT:
-        case MILPSolverBoundTighteningType::BACKWARD_ANALYSIS_PMNR_BBPS:
+        case MILPSolverBoundTighteningType::BACKWARD_ANALYSIS_PMNR:
         case MILPSolverBoundTighteningType::ITERATIVE_PROPAGATION:
         case MILPSolverBoundTighteningType::NONE:
             return;

--- a/src/engine/GroundBoundManager.cpp
+++ b/src/engine/GroundBoundManager.cpp
@@ -1,0 +1,161 @@
+/*********************                                                        */
+/*! \file GroundBoundManager.cpp
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Idan Refaeli, Omri Isac
+ ** This file is part of the Marabou project.
+ ** Copyright (c) 2017-2025 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved. See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** [[ Add lengthier description here ]]
+
+**/
+
+#include "GroundBoundManager.h"
+
+#include "FloatUtils.h"
+
+
+GroundBoundManager::GroundBoundManager( CVC4::context::Context &ctx )
+    : _context( ctx )
+    , _size( 0 )
+    , _upperGroundBounds( 0 )
+    , _lowerGroundBounds( 0 )
+{
+    _counter = new ( true ) CVC4::context::CDO<unsigned>( &_context, 0 );
+}
+
+GroundBoundManager::~GroundBoundManager()
+{
+    _counter->deleteSelf();
+    for ( unsigned i = 0; i < _size; ++i )
+    {
+        _upperGroundBounds[i]->deleteSelf();
+        _lowerGroundBounds[i]->deleteSelf();
+    }
+}
+
+void GroundBoundManager::initialize( unsigned size )
+{
+    _counter->set( 0 );
+    _size = size;
+
+    for ( unsigned i = 0; i < size; ++i )
+    {
+        _upperGroundBounds.append(
+            new ( true ) CVC4::context::CDList<std::shared_ptr<GroundBoundEntry>>( &_context ) );
+        _lowerGroundBounds.append(
+            new ( true ) CVC4::context::CDList<std::shared_ptr<GroundBoundEntry>>( &_context ) );
+    }
+}
+
+std::shared_ptr<GroundBoundManager::GroundBoundEntry>
+GroundBoundManager::addGroundBound( unsigned index,
+                                    double value,
+                                    Tightening::BoundType boundType,
+                                    bool isPhaseFixing )
+{
+    const Vector<CVC4::context::CDList<std::shared_ptr<GroundBoundEntry>> *> &temp =
+        boundType == Tightening::UB ? _upperGroundBounds : _lowerGroundBounds;
+
+    std::shared_ptr<GroundBoundEntry> groundBoundEntry(
+        new GroundBoundEntry( _counter->get(), value, nullptr, isPhaseFixing ) );
+
+    if ( !temp[index]->empty() )
+    {
+        ASSERT( boundType == Tightening::UB ? FloatUtils::lte( value, temp[index]->back()->val )
+                                            : FloatUtils::gte( value, temp[index]->back()->val ) )
+    }
+
+    temp[index]->push_back( groundBoundEntry );
+    _counter->set( _counter->get() + 1 );
+
+    return temp[index]->back();
+}
+
+std::shared_ptr<GroundBoundManager::GroundBoundEntry>
+GroundBoundManager::addGroundBound( const std::shared_ptr<PLCLemma> &lemma, bool isPhaseFixing )
+{
+    Tightening::BoundType isUpper = lemma->getAffectedVarBound();
+    unsigned index = lemma->getAffectedVar();
+
+    const Vector<CVC4::context::CDList<std::shared_ptr<GroundBoundEntry>> *> &temp =
+        isUpper == Tightening::UB ? _upperGroundBounds : _lowerGroundBounds;
+
+    std::shared_ptr<GroundBoundEntry> groundBoundEntry(
+        new GroundBoundEntry( _counter->get(), lemma->getBound(), lemma, isPhaseFixing ) );
+
+    if ( !temp[index]->empty() )
+    {
+        ASSERT( isUpper == Tightening::UB
+                    ? FloatUtils::lte( lemma->getBound(), temp[index]->back()->val )
+                    : FloatUtils::gte( lemma->getBound(), temp[index]->back()->val ) )
+    }
+
+    temp[index]->push_back( groundBoundEntry );
+    _counter->set( _counter->get() + 1 );
+
+    return temp[index]->back();
+}
+
+double GroundBoundManager::getGroundBound( unsigned index, Tightening::BoundType boundType ) const
+{
+    const Vector<CVC4::context::CDList<std::shared_ptr<GroundBoundEntry>> *> &temp =
+        boundType == Tightening::UB ? _upperGroundBounds : _lowerGroundBounds;
+    return temp[index]->back()->val;
+}
+
+std::shared_ptr<GroundBoundManager::GroundBoundEntry>
+GroundBoundManager::getGroundBoundEntry( unsigned int index, Tightening::BoundType boundType ) const
+{
+    const Vector<CVC4::context::CDList<std::shared_ptr<GroundBoundEntry>> *> &temp =
+        boundType == Tightening::UB ? _upperGroundBounds : _lowerGroundBounds;
+    return temp[index]->back();
+}
+
+std::shared_ptr<GroundBoundManager::GroundBoundEntry>
+GroundBoundManager::getGroundBoundEntryUpToId( unsigned index,
+                                               Tightening::BoundType boundType,
+                                               unsigned id ) const
+{
+    const Vector<CVC4::context::CDList<std::shared_ptr<GroundBoundEntry>> *> &temp =
+        boundType == Tightening::UB ? _upperGroundBounds : _lowerGroundBounds;
+
+    if ( id == 0 )
+        return ( *temp[index] )[0];
+
+    for ( int i = temp[index]->size() - 1; i >= 0; --i )
+    {
+        const std::shared_ptr<GroundBoundEntry> entry = ( *temp[index] )[i];
+        if ( entry->id < id )
+            return entry;
+    }
+    ASSERT( id <= 2 * temp.size() );
+    return ( *temp[index] )[0];
+}
+
+double GroundBoundManager::getGroundBoundUpToId( unsigned index,
+                                                 Tightening::BoundType boundType,
+                                                 unsigned id ) const
+{
+    return getGroundBoundEntryUpToId( index, boundType, id )->val;
+}
+
+Vector<double> GroundBoundManager::getAllGroundBounds( Tightening::BoundType boundType ) const
+{
+    const Vector<CVC4::context::CDList<std::shared_ptr<GroundBoundEntry>> *> &temp =
+        boundType == Tightening::UB ? _upperGroundBounds : _lowerGroundBounds;
+    Vector<double> tops = Vector<double>( 0 );
+
+    for ( const auto &GBList : temp )
+        tops.append( GBList->back()->val );
+
+    return tops;
+}
+
+unsigned GroundBoundManager::getCounter() const
+{
+    return _counter->get();
+}

--- a/src/engine/GroundBoundManager.h
+++ b/src/engine/GroundBoundManager.h
@@ -1,0 +1,109 @@
+/*********************                                                        */
+/*! \file GroundBoundManager.h
+ ** \verbatim
+ ** Top contributors (to current version):
+ **   Idan Refaeli, Omri Isac
+ ** This file is part of the Marabou project.
+ ** Copyright (c) 2017-2025 by the authors listed in the file AUTHORS
+ ** in the top-level source directory) and their institutional affiliations.
+ ** All rights reserved. See the file COPYING in the top-level source
+ ** directory for licensing information.\endverbatim
+ **
+ ** [[ Add lengthier description here ]]
+
+**/
+
+#ifndef __GroundBoundManager_h__
+#define __GroundBoundManager_h__
+
+#include "PlcLemma.h"
+#include "Set.h"
+#include "Tightening.h"
+#include "Vector.h"
+#include "context/cdlist.h"
+#include "context/cdo.h"
+#include "context/context.h"
+
+/*
+ A class to manage all ground bounds updates
+*/
+class GroundBoundManager
+{
+public:
+    /*
+     A struct representing ground bounds, whose derivation cannot be explained using a single Farkas
+     vector. Entries include bookkeeping of data used for proof minimization, such as a unique id
+     and the lemma used for derivation
+    */
+    struct GroundBoundEntry
+    {
+        GroundBoundEntry( unsigned id,
+                          double val,
+                          const std::shared_ptr<PLCLemma> &lemma,
+                          bool isPhaseFixing )
+            : id( id )
+            , val( val )
+            , lemma( lemma )
+            , isPhaseFixing( isPhaseFixing )
+        {
+        }
+        unsigned id;
+        double val;
+        const std::shared_ptr<PLCLemma> lemma;
+        bool isPhaseFixing; // Preparation for CDCL-based solving
+        Set<std::shared_ptr<GroundBoundManager::GroundBoundEntry>> depList;
+    };
+
+    GroundBoundManager( CVC4::context::Context &ctx );
+    ~GroundBoundManager();
+
+    /*
+     Initialize internal data structures
+    */
+    void initialize( unsigned size );
+
+    /*
+     Update the ground bounds, manually or by learning a lemma
+    */
+    std::shared_ptr<GroundBoundManager::GroundBoundEntry>
+    addGroundBound( unsigned index,
+                    double value,
+                    Tightening::BoundType boundType,
+                    bool isPhaseFixing );
+
+    std::shared_ptr<GroundBoundManager::GroundBoundEntry>
+    addGroundBound( const std::shared_ptr<PLCLemma> &lemma, bool isPhaseFixing );
+
+    /*
+     Getters for ground bounds
+    */
+    double getGroundBound( unsigned index, Tightening::BoundType boundType ) const;
+
+    std::shared_ptr<GroundBoundManager::GroundBoundEntry>
+    getGroundBoundEntry( unsigned index, Tightening::BoundType boundType ) const;
+
+    std::shared_ptr<GroundBoundManager::GroundBoundEntry>
+    getGroundBoundEntryUpToId( unsigned index, Tightening::BoundType boundType, unsigned id ) const;
+
+    double
+    getGroundBoundUpToId( unsigned index, Tightening::BoundType boundType, unsigned id ) const;
+
+    Vector<double> getAllGroundBounds( Tightening::BoundType boundType ) const;
+
+    /*
+     Get the current value of the unique id counter
+    */
+    unsigned getCounter() const;
+
+private:
+    CVC4::context::CDO<unsigned> *_counter;
+
+    CVC4::context::Context &_context;
+    unsigned _size;
+
+    Vector<CVC4::context::CDList<std::shared_ptr<GroundBoundEntry>> *> _upperGroundBounds;
+    Vector<CVC4::context::CDList<std::shared_ptr<GroundBoundEntry>> *> _lowerGroundBounds;
+};
+
+
+#endif // __GroundBoundManager_h__

--- a/src/engine/IEngine.h
+++ b/src/engine/IEngine.h
@@ -18,6 +18,8 @@
 
 #include "BoundExplainer.h"
 #include "DivideStrategy.h"
+#include "GroundBoundManager.h"
+#include "LPSolverType.h"
 #include "List.h"
 #include "PlcLemma.h"
 #include "SnCDivideStrategy.h"
@@ -121,12 +123,6 @@ public:
     */
     virtual double explainBound( unsigned var, bool isUpper ) const = 0;
 
-    /*
-      Update the ground bounds
-      */
-    virtual void updateGroundUpperBound( unsigned var, double value ) = 0;
-    virtual void updateGroundLowerBound( unsigned var, double value ) = 0;
-
     virtual void applyAllBoundTightenings() = 0;
 
     virtual bool applyAllValidConstraintCaseSplits() = 0;
@@ -146,6 +142,8 @@ public:
       Get the ground bound of the variable
     */
     virtual double getGroundBound( unsigned var, bool isUpper ) const = 0;
+    virtual std::shared_ptr<GroundBoundManager::GroundBoundEntry>
+    getGroundBoundEntry( unsigned var, bool isUpper ) const = 0;
 
     /*
       Get the current pointer in the UNSAT certificate node
@@ -191,6 +189,12 @@ public:
       Add lemma to the UNSAT Certificate
     */
     virtual void incNumOfLemmas() = 0;
+
+    /*
+      Add ground bound entry using a lemma
+    */
+    virtual std::shared_ptr<GroundBoundManager::GroundBoundEntry>
+    setGroundBoundFromLemma( const std::shared_ptr<PLCLemma> lemma, bool isPhaseFixing ) = 0;
 
     virtual const List<PiecewiseLinearConstraint *> *getPiecewiseLinearConstraints() const = 0;
 };

--- a/src/engine/MILPSolverBoundTighteningType.h
+++ b/src/engine/MILPSolverBoundTighteningType.h
@@ -37,18 +37,11 @@ enum class MILPSolverBoundTighteningType {
     // Perform backward analysis using the PreimageApproximation Algorithm (arXiv:2305.03686v4
     // [cs.SE])
     BACKWARD_ANALYSIS_PREIMAGE_APPROX = 7,
-    // Perform backward analysis using INVPROP (arXiv:2302.01404v4 [cs.LG])
-    BACKWARD_ANALYSIS_INVPROP = 8,
-    // Perform backward analysis using PMNR with random neuron selection.
-    BACKWARD_ANALYSIS_PMNR_RANDOM = 9,
-    // Perform backward analysis using PMNR with maximum gradient neuron selection (arXiv:1804.10829
-    // [cs.AI]).
-    BACKWARD_ANALYSIS_PMNR_GRADIENT = 10,
-    // Perform backward analysis using PMNR with BBPS-based neuron selection (arXiv:2405.21063v3
-    // [cs.LG]).
-    BACKWARD_ANALYSIS_PMNR_BBPS = 11,
+    // Perform backward analysis using PMNR with INVPROP and BBPS-based neuron selection
+    // (arXiv:2302.01404v4 [cs.LG], arXiv:2405.21063v3 [cs.LG]).
+    BACKWARD_ANALYSIS_PMNR = 8,
     // Option to have no MILP bound tightening performed
-    NONE = 20,
+    NONE = 9,
 };
 
 #endif // __MILPSolverBoundTighteningType_h__

--- a/src/engine/PiecewiseLinearConstraint.cpp
+++ b/src/engine/PiecewiseLinearConstraint.cpp
@@ -30,6 +30,7 @@ PiecewiseLinearConstraint::PiecewiseLinearConstraint()
     , _score( FloatUtils::negativeInfinity() )
     , _statistics( NULL )
     , _gurobi( NULL )
+    , _cdPhaseFixingEntry( nullptr )
     , _tableauAuxVars()
 {
 }
@@ -47,6 +48,7 @@ PiecewiseLinearConstraint::PiecewiseLinearConstraint( unsigned numCases )
     , _score( FloatUtils::negativeInfinity() )
     , _statistics( NULL )
     , _gurobi( NULL )
+    , _cdPhaseFixingEntry( nullptr )
     , _tableauAuxVars()
 {
 }
@@ -81,6 +83,7 @@ void PiecewiseLinearConstraint::initializeCDOs( CVC4::context::Context *context 
     initializeCDActiveStatus();
     initializeCDPhaseStatus();
     initializeCDInfeasibleCases();
+    initializeCDPhaseFixingEntry();
 }
 
 void PiecewiseLinearConstraint::initializeCDInfeasibleCases()
@@ -104,6 +107,14 @@ void PiecewiseLinearConstraint::initializeCDPhaseStatus()
     _cdPhaseStatus = new ( true ) CVC4::context::CDO<PhaseStatus>( _context, _phaseStatus );
 }
 
+void PiecewiseLinearConstraint::initializeCDPhaseFixingEntry()
+{
+    ASSERT( _context != nullptr );
+    ASSERT( _cdPhaseFixingEntry == nullptr );
+    _cdPhaseFixingEntry = new ( true )
+        CVC4::context::CDO<std::shared_ptr<GroundBoundManager::GroundBoundEntry>>( _context );
+}
+
 void PiecewiseLinearConstraint::cdoCleanup()
 {
     if ( _cdConstraintActive != nullptr )
@@ -120,6 +131,11 @@ void PiecewiseLinearConstraint::cdoCleanup()
         _cdInfeasibleCases->deleteSelf();
 
     _cdInfeasibleCases = nullptr;
+
+    if ( _cdPhaseFixingEntry != nullptr )
+        _cdPhaseFixingEntry->deleteSelf();
+
+    _cdPhaseFixingEntry = nullptr;
 
     _context = nullptr;
 }
@@ -158,6 +174,10 @@ void PiecewiseLinearConstraint::initializeDuplicateCDOs( PiecewiseLinearConstrai
         clone->_cdInfeasibleCases = nullptr;
         clone->initializeCDInfeasibleCases();
         // Does not copy contents
+
+        ASSERT( clone->_cdPhaseFixingEntry != nullptr )
+        clone->_cdPhaseFixingEntry = nullptr;
+        clone->initializeCDPhaseFixingEntry();
     }
 }
 

--- a/src/engine/SignConstraint.cpp
+++ b/src/engine/SignConstraint.cpp
@@ -389,6 +389,9 @@ void SignConstraint::notifyLowerBound( unsigned variable, double bound )
     // Otherwise - update bound
     setLowerBound( variable, bound );
 
+    if ( phaseFixed() )
+        return;
+
     if ( variable == _f && FloatUtils::gt( bound, -1 ) )
     {
         setPhaseStatus( PhaseStatus::SIGN_PHASE_POSITIVE );
@@ -439,6 +442,9 @@ void SignConstraint::notifyUpperBound( unsigned variable, double bound )
 
     // Otherwise - update bound
     setUpperBound( variable, bound );
+
+    if ( phaseFixed() )
+        return;
 
     if ( variable == _f && FloatUtils::lt( bound, 1 ) )
     {

--- a/src/engine/tests/MockEngine.h
+++ b/src/engine/tests/MockEngine.h
@@ -72,7 +72,7 @@ public:
     List<Bound> lastLowerBounds;
     List<Bound> lastUpperBounds;
     List<Equation> lastEquations;
-    void applySplit( const PiecewiseLinearCaseSplit &split )
+    void applySplit( const PiecewiseLinearCaseSplit &split ) override
     {
         List<Tightening> bounds = split.getBoundTightenings();
         auto equations = split.getEquations();
@@ -94,29 +94,29 @@ public:
         }
     }
 
-    void postContextPopHook(){};
+    void postContextPopHook() override{};
 
-    void preContextPushHook(){};
+    void preContextPushHook() override{};
 
     mutable EngineState *lastStoredState;
-    void storeState( EngineState &state, TableauStateStorageLevel /*level*/ ) const
+    void storeState( EngineState &state, TableauStateStorageLevel /*level*/ ) const override
     {
         lastStoredState = &state;
     }
 
     const EngineState *lastRestoredState;
-    void restoreState( const EngineState &state )
+    void restoreState( const EngineState &state ) override
     {
         lastRestoredState = &state;
     }
 
-    void setNumPlConstraintsDisabledByValidSplits( unsigned /* numConstraints */ )
+    void setNumPlConstraintsDisabledByValidSplits( unsigned /* numConstraints */ ) override
     {
     }
 
     unsigned _timeToSolve;
     IEngine::ExitCode _exitCode;
-    bool solve( double timeoutInSeconds )
+    bool solve( double timeoutInSeconds ) override
     {
         if ( timeoutInSeconds >= _timeToSolve )
             _exitCode = IEngine::TIMEOUT;
@@ -133,12 +133,12 @@ public:
         _exitCode = exitCode;
     }
 
-    IEngine::ExitCode getExitCode() const
+    IEngine::ExitCode getExitCode() const override
     {
         return _exitCode;
     }
 
-    void reset()
+    void reset() override
     {
     }
 
@@ -148,7 +148,7 @@ public:
         _inputVariables = inputVariables;
     }
 
-    List<unsigned> getInputVariables() const
+    List<unsigned> getInputVariables() const override
     {
         return _inputVariables;
     }
@@ -158,14 +158,14 @@ public:
     }
 
     mutable SearchTreeState *lastRestoredSearchTreeState;
-    bool restoreSearchTreeState( SearchTreeState &searchTreeState )
+    bool restoreSearchTreeState( SearchTreeState &searchTreeState ) override
     {
         lastRestoredSearchTreeState = &searchTreeState;
         return true;
     }
 
     mutable SearchTreeState *lastStoredSearchTreeState;
-    void storeSearchTreeState( SearchTreeState &searchTreeState )
+    void storeSearchTreeState( SearchTreeState &searchTreeState ) override
     {
         lastStoredSearchTreeState = &searchTreeState;
     }
@@ -176,7 +176,7 @@ public:
         _constraintsToSplit.append( constraint );
     }
 
-    PiecewiseLinearConstraint *pickSplitPLConstraint( DivideStrategy /**/ )
+    PiecewiseLinearConstraint *pickSplitPLConstraint( DivideStrategy /**/ ) override
     {
         if ( !_constraintsToSplit.empty() )
         {
@@ -188,7 +188,7 @@ public:
             return NULL;
     }
 
-    PiecewiseLinearConstraint *pickSplitPLConstraintSnC( SnCDivideStrategy /**/ )
+    PiecewiseLinearConstraint *pickSplitPLConstraintSnC( SnCDivideStrategy /**/ ) override
     {
         if ( !_constraintsToSplit.empty() )
         {
@@ -203,35 +203,35 @@ public:
     bool _snc;
     CVC4::context::Context _context;
 
-    void applySnCSplit( PiecewiseLinearCaseSplit /*split*/, String /*queryId*/ )
+    void applySnCSplit( PiecewiseLinearCaseSplit /*split*/, String /*queryId*/ ) override
     {
         _snc = true;
         _context.push();
     }
 
-    bool inSnCMode() const
+    bool inSnCMode() const override
     {
         return _snc;
     }
 
-    void applyAllBoundTightenings(){};
+    void applyAllBoundTightenings() override{};
 
-    bool applyAllValidConstraintCaseSplits()
+    bool applyAllValidConstraintCaseSplits() override
     {
         return false;
     };
 
-    CVC4::context::Context &getContext()
+    CVC4::context::Context &getContext() override
     {
         return _context;
     }
 
-    bool consistentBounds() const
+    bool consistentBounds() const override
     {
         return true;
     }
 
-    double explainBound( unsigned /* var */, bool /* isUpper */ ) const
+    double explainBound( unsigned /* var */, bool /* isUpper */ ) const override
     {
         return 0.0;
     }
@@ -240,52 +240,64 @@ public:
 
     void updateGroundLowerBound( unsigned /*var*/, double /*value*/ ){};
 
-    double getGroundBound( unsigned /*var*/, bool /*isUpper*/ ) const
+    double getGroundBound( unsigned /*var*/, bool /*isUpper*/ ) const override
     {
         return 0;
     }
+    std::shared_ptr<GroundBoundManager::GroundBoundEntry>
+    getGroundBoundEntry( unsigned /*var*/, bool /*isUpper*/ ) const override
+    {
+        return nullptr;
+    }
 
-    UnsatCertificateNode *getUNSATCertificateCurrentPointer() const
+    UnsatCertificateNode *getUNSATCertificateCurrentPointer() const override
     {
         return NULL;
     }
 
-    void setUNSATCertificateCurrentPointer( UnsatCertificateNode * /* node*/ ){};
+    void setUNSATCertificateCurrentPointer( UnsatCertificateNode * /* node*/ ) override{};
 
-    const UnsatCertificateNode *getUNSATCertificateRoot() const
+    const UnsatCertificateNode *getUNSATCertificateRoot() const override
     {
         return NULL;
     }
 
-    bool certifyUNSATCertificate()
+    bool certifyUNSATCertificate() override
     {
         return true;
     }
 
-    void explainSimplexFailure(){};
+    void explainSimplexFailure() override{};
 
-    const BoundExplainer *getBoundExplainer() const
+    const BoundExplainer *getBoundExplainer() const override
     {
         return NULL;
     }
 
-    void setBoundExplainerContent( BoundExplainer * /*boundExplainer */ ){};
+    void setBoundExplainerContent( BoundExplainer * /*boundExplainer */ ) override{};
 
-    void propagateBoundManagerTightenings()
+    void propagateBoundManagerTightenings() override
     {
     }
 
-    bool shouldProduceProofs() const
+    bool shouldProduceProofs() const override
     {
         return true;
     }
 
-    const List<PiecewiseLinearConstraint *> *getPiecewiseLinearConstraints() const
+    std::shared_ptr<GroundBoundManager::GroundBoundEntry>
+    setGroundBoundFromLemma( const std::shared_ptr<PLCLemma> /*lemma*/,
+                             bool /*isPhaseFixing*/ ) override
+    {
+        return nullptr;
+    }
+
+    const List<PiecewiseLinearConstraint *> *getPiecewiseLinearConstraints() const override
     {
         return NULL;
     }
 
-    void incNumOfLemmas(){};
+    void incNumOfLemmas() override{};
 };
 
 #endif // __MockEngine_h__

--- a/src/engine/tests/Test_SignConstraint.h
+++ b/src/engine/tests/Test_SignConstraint.h
@@ -888,16 +888,18 @@ public:
                 // Tighter lower bound for b/f that is positive
                 MockBoundManager boundManager;
                 boundManager.initialize( 6 );
-                SignConstraint sign = prepareSign( b, f, &boundManager );
+                SignConstraint sign1 = prepareSign( b, f, &boundManager );
+                SignConstraint sign2 = prepareSign( b, f, &boundManager );
+
                 boundManager.clearTightenings();
 
-                sign.notifyLowerBound( b, 1 );
+                sign1.notifyLowerBound( b, 1 );
                 boundManager.getTightenings( tightenings );
                 TS_ASSERT_EQUALS( tightenings.size(), 1U );
                 TS_ASSERT( tightenings.exists( Tightening( f, 1, Tightening::LB ) ) );
                 tightenings.clear();
 
-                sign.notifyUpperBound( f, -0.5 );
+                sign2.notifyUpperBound( f, -0.5 );
                 boundManager.getTightenings( tightenings );
                 TS_ASSERT( tightenings.exists( Tightening( f, -1, Tightening::UB ) ) );
                 tightenings.clear();

--- a/src/nlr/Layer.cpp
+++ b/src/nlr/Layer.cpp
@@ -79,13 +79,7 @@ void Layer::allocateMemory()
          Options::get()->getMILPSolverBoundTighteningType() ==
              MILPSolverBoundTighteningType::BACKWARD_ANALYSIS_PREIMAGE_APPROX ||
          Options::get()->getMILPSolverBoundTighteningType() ==
-             MILPSolverBoundTighteningType::BACKWARD_ANALYSIS_INVPROP ||
-         Options::get()->getMILPSolverBoundTighteningType() ==
-             MILPSolverBoundTighteningType::BACKWARD_ANALYSIS_PMNR_RANDOM ||
-         Options::get()->getMILPSolverBoundTighteningType() ==
-             MILPSolverBoundTighteningType::BACKWARD_ANALYSIS_PMNR_GRADIENT ||
-         Options::get()->getMILPSolverBoundTighteningType() ==
-             MILPSolverBoundTighteningType::BACKWARD_ANALYSIS_PMNR_BBPS )
+             MILPSolverBoundTighteningType::BACKWARD_ANALYSIS_PMNR )
     {
         _symbolicLb = new double[_size * _inputLayerSize];
         _symbolicUb = new double[_size * _inputLayerSize];

--- a/src/nlr/NetworkLevelReasoner.h
+++ b/src/nlr/NetworkLevelReasoner.h
@@ -355,15 +355,11 @@ private:
                                             Map<unsigned, double> &point,
                                             unsigned i ) const;
 
-    // Heuristically generating optimizable polygonal tightening for INVPROP or PMNR.
-    const Vector<PolygonalTightening> generatePolygonalTightenings();
+    // Heuristically generating optimizable polygonal tightening for PMNR.
     const Vector<PolygonalTightening> generatePolygonalTighteningsForPMNR();
-    const Vector<PolygonalTightening> generatePolygonalTighteningsForInvprop();
 
     // Heuristically select neurons for PMNR.
     const Vector<NeuronIndex> selectPMNRNeurons();
-    const Vector<NeuronIndex> selectPMNRNeuronsRandomly();
-    const Vector<NeuronIndex> selectPMNRNeuronsHeuristically();
 
     // Optimize biases of generated parameterised polygonal tightenings.
     double OptimizeSingleParameterisedPolygonalTightening(
@@ -381,7 +377,6 @@ private:
 
     // Get current lower bound for selected parameterised polygonal tightenings' biases.
     double getParameterisdPolygonalTighteningBound(
-        const Vector<double> &coeffs,
         const Vector<double> &gamma,
         PolygonalTightening &tightening,
         Vector<PolygonalTightening> &prevTightenings,
@@ -396,8 +391,6 @@ private:
 
     // Calculate PMNRScore for every non-fixed neurons.
     void initializePMNRScoreMap();
-    double calculateNeuronPMNRScore( NeuronIndex index );
-    double calculatePMNRGradientScore( NeuronIndex index );
     double calculatePMNRBBPSScore( NeuronIndex index );
 
     // Initialize PMNR-BBPS branching point scores and per-branch predecessor symbolic bounds for

--- a/src/nlr/tests/Test_LPRelaxation.h
+++ b/src/nlr/tests/Test_LPRelaxation.h
@@ -4462,7 +4462,7 @@ public:
         } );
 
         TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( bounds, newBounds );
+        TS_ASSERT_THROWS_NOTHING( bounds = removeRedundancies( newBounds, bounds ) );
         TS_ASSERT( boundsEqual( bounds, expectedBounds2 ) );
 
         // Change the current bounds
@@ -4530,7 +4530,7 @@ public:
         } );
 
         TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( bounds, newBounds );
+        TS_ASSERT_THROWS_NOTHING( bounds = removeRedundancies( newBounds, bounds ) );
         TS_ASSERT( boundsEqual( bounds, expectedBounds4 ) );
     }
 
@@ -4614,7 +4614,7 @@ public:
         } );
 
         TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( bounds, newBounds );
+        TS_ASSERT_THROWS_NOTHING( bounds = removeRedundancies( newBounds, bounds ) );
         TS_ASSERT( boundsEqual( bounds, expectedBounds2 ) );
 
         // Change the current bounds
@@ -4730,7 +4730,7 @@ public:
         } );
 
         TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( bounds, newBounds );
+        TS_ASSERT_THROWS_NOTHING( bounds = removeRedundancies( newBounds, bounds ) );
         TS_ASSERT( boundsEqual( bounds, expectedBounds4 ) );
     }
 
@@ -4795,7 +4795,7 @@ public:
         } );
 
         TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( bounds, newBounds );
+        TS_ASSERT_THROWS_NOTHING( bounds = removeRedundancies( newBounds, bounds ) );
         TS_ASSERT( boundsEqual( bounds, expectedBounds2 ) );
 
         // Change the current bounds
@@ -4876,7 +4876,7 @@ public:
         } );
 
         TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( bounds, newBounds );
+        TS_ASSERT_THROWS_NOTHING( bounds = removeRedundancies( newBounds, bounds ) );
         TS_ASSERT( boundsEqual( bounds, expectedBounds4 ) );
     }
 
@@ -4961,7 +4961,7 @@ public:
         } );
 
         TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( bounds, newBounds );
+        TS_ASSERT_THROWS_NOTHING( bounds = removeRedundancies( newBounds, bounds ) );
         TS_ASSERT( boundsEqual( bounds, expectedBounds2 ) );
 
         // Change the current bounds
@@ -5074,7 +5074,7 @@ public:
         } );
 
         TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( bounds, newBounds );
+        TS_ASSERT_THROWS_NOTHING( bounds = removeRedundancies( newBounds, bounds ) );
         TS_ASSERT( boundsEqual( bounds, expectedBounds4 ) );
     }
 
@@ -5127,7 +5127,7 @@ public:
         List<Tightening> expectedBounds2( {} );
 
         TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( bounds, newBounds );
+        TS_ASSERT_THROWS_NOTHING( bounds = removeRedundancies( newBounds, bounds ) );
         TS_ASSERT( boundsEqual( bounds, expectedBounds2 ) );
 
         // Change the current bounds
@@ -5190,7 +5190,7 @@ public:
         List<Tightening> expectedBounds4( {} );
 
         TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( bounds, newBounds );
+        TS_ASSERT_THROWS_NOTHING( bounds = removeRedundancies( newBounds, bounds ) );
         TS_ASSERT( boundsEqual( bounds, expectedBounds4 ) );
     }
 
@@ -5256,7 +5256,7 @@ public:
         List<Tightening> expectedBounds2( {} );
 
         TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( bounds, newBounds );
+        TS_ASSERT_THROWS_NOTHING( bounds = removeRedundancies( newBounds, bounds ) );
         TS_ASSERT( boundsEqual( bounds, expectedBounds2 ) );
 
         // Change the current bounds
@@ -5350,7 +5350,7 @@ public:
         List<Tightening> expectedBounds4( {} );
 
         TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( bounds, newBounds );
+        TS_ASSERT_THROWS_NOTHING( bounds = removeRedundancies( newBounds, bounds ) );
         TS_ASSERT( boundsEqual( bounds, expectedBounds4 ) );
     }
 
@@ -5406,7 +5406,7 @@ public:
         } );
 
         TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( bounds, newBounds );
+        TS_ASSERT_THROWS_NOTHING( bounds = removeRedundancies( newBounds, bounds ) );
         TS_ASSERT( boundsEqual( bounds, expectedBounds2 ) );
 
         // Change the current bounds
@@ -5480,7 +5480,7 @@ public:
         } );
 
         TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( bounds, newBounds );
+        TS_ASSERT_THROWS_NOTHING( bounds = removeRedundancies( newBounds, bounds ) );
         TS_ASSERT( boundsEqual( bounds, expectedBounds4 ) );
     }
 
@@ -5546,7 +5546,7 @@ public:
         } );
 
         TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( bounds, newBounds );
+        TS_ASSERT_THROWS_NOTHING( bounds = removeRedundancies( newBounds, bounds ) );
         TS_ASSERT( boundsEqual( bounds, expectedBounds2 ) );
 
         // Change the current bounds
@@ -5631,7 +5631,7 @@ public:
         } );
 
         TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( bounds, newBounds );
+        TS_ASSERT_THROWS_NOTHING( bounds = removeRedundancies( newBounds, bounds ) );
         TS_ASSERT( boundsEqual( bounds, expectedBounds4 ) );
     }
 
@@ -5656,38 +5656,45 @@ public:
         return allFound;
     }
 
-    // Create list of all tightenings in newBounds for which there is no bound in newBounds or in
-    // bounds which is at least as tight.
-    List<Tightening> removeRedundancies( const List<Tightening> &bounds,
-                                         const List<Tightening> &newBounds )
+    // Create list of all tightenings in bounds for which there is no bound in newBounds
+    // or in previousBounds which is at least as tight.
+    List<Tightening> removeRedundancies( const List<Tightening> &newBounds,
+                                         const List<Tightening> &bounds )
     {
         List<Tightening> minimalBounds;
-
-        for ( const auto &newBound : newBounds )
+        unsigned i = 0;
+        for ( const auto &bound : newBounds )
         {
             bool foundTighter = false;
-            for ( const auto &bound : bounds )
+            unsigned j = 0;
+            for ( const auto &otherBound : newBounds )
+            {
+                if ( i < j )
+                {
+                    foundTighter |=
+                        ( bound._type == otherBound._type &&
+                          bound._variable == otherBound._variable &&
+                          ( ( bound._type == Tightening::LB &&
+                              FloatUtils::lte( bound._value, otherBound._value, 0.0001 ) ) ||
+                            ( bound._type == Tightening::UB &&
+                              FloatUtils::gte( bound._value, otherBound._value, 0.0001 ) ) ) );
+                }
+                ++j;
+            }
+            for ( const auto &otherBound : bounds )
             {
                 foundTighter |=
-                    ( newBound._type == bound._type && newBound._variable == bound._variable &&
-                      ( ( newBound._type == Tightening::LB &&
-                          FloatUtils::lte( newBound._value, bound._value, 0.0001 ) ) ||
-                        ( newBound._type == Tightening::UB &&
-                          FloatUtils::gte( newBound._value, bound._value, 0.0001 ) ) ) );
+                    ( bound._type == otherBound._type && bound._variable == otherBound._variable &&
+                      ( ( bound._type == Tightening::LB &&
+                          FloatUtils::lte( bound._value, otherBound._value, 0.0001 ) ) ||
+                        ( bound._type == Tightening::UB &&
+                          FloatUtils::gte( bound._value, otherBound._value, 0.0001 ) ) ) );
             }
-
-            for ( const auto &bound : newBounds )
-            {
-                foundTighter |=
-                    ( newBound._type == bound._type && newBound._variable == bound._variable &&
-                      ( ( newBound._type == Tightening::LB &&
-                          FloatUtils::lt( newBound._value, bound._value, 0.0001 ) ) ||
-                        ( newBound._type == Tightening::UB &&
-                          FloatUtils::gt( newBound._value, bound._value, 0.0001 ) ) ) );
-            }
-
             if ( !foundTighter )
-                minimalBounds.append( newBound );
+            {
+                minimalBounds.append( bound );
+            }
+            ++i;
         }
         return minimalBounds;
     }

--- a/src/nlr/tests/Test_PMNR.h
+++ b/src/nlr/tests/Test_PMNR.h
@@ -548,102 +548,6 @@ public:
         tableau.setUpperBound( 11, large );
     }
 
-    void populateNetworkMinimalReLU( NLR::NetworkLevelReasoner &nlr, MockTableau &tableau )
-    {
-        /*
-              1      R       1      R      -1   1
-          x0 --- x2 ---> x4 --- x6 ---> x8 --- x10
-            \    /         \    /              /
-           1 \  /         0 \  /              /
-              \/             \/              /
-              /\             /\             /
-           1 /  \         2 /  \        -1 /
-            /    \   R     /    \   R     /
-          x1 --- x3 ---> x5 --- x7 ---> x9
-             -1              1  1.5
-
-          The example described in Fig. 2 of
-          https://proceedings.neurips.cc/paper_files/paper/2019/file/0a9fdbb17feb6ccb7ec405cfb85222c4-Paper.pdf
-        */
-
-        // Create the layers
-        nlr.addLayer( 0, NLR::Layer::INPUT, 2 );
-        nlr.addLayer( 1, NLR::Layer::WEIGHTED_SUM, 2 );
-        nlr.addLayer( 2, NLR::Layer::RELU, 2 );
-        nlr.addLayer( 3, NLR::Layer::WEIGHTED_SUM, 2 );
-        nlr.addLayer( 4, NLR::Layer::RELU, 2 );
-        nlr.addLayer( 5, NLR::Layer::WEIGHTED_SUM, 1 );
-
-        // Mark layer dependencies
-        for ( unsigned i = 1; i <= 5; ++i )
-            nlr.addLayerDependency( i - 1, i );
-
-        // Set the weights and biases for the weighted sum layers
-        nlr.setWeight( 0, 0, 1, 0, 1 );
-        nlr.setWeight( 0, 0, 1, 1, 1 );
-        nlr.setWeight( 0, 1, 1, 0, 1 );
-        nlr.setWeight( 0, 1, 1, 1, -1 );
-
-        nlr.setWeight( 2, 0, 3, 0, 1 );
-        nlr.setWeight( 2, 0, 3, 1, 0 );
-        nlr.setWeight( 2, 1, 3, 0, 2 );
-        nlr.setWeight( 2, 1, 3, 1, 1 );
-
-        nlr.setWeight( 4, 0, 5, 0, -1 );
-        nlr.setWeight( 4, 1, 5, 0, 1 );
-
-        nlr.setBias( 3, 1, 1.5 );
-        nlr.setBias( 5, 0, 1 );
-
-        // Mark the ReLU sources
-        nlr.addActivationSource( 1, 0, 2, 0 );
-        nlr.addActivationSource( 1, 1, 2, 1 );
-
-        nlr.addActivationSource( 3, 0, 4, 0 );
-        nlr.addActivationSource( 3, 1, 4, 1 );
-
-        // Variable indexing
-        nlr.setNeuronVariable( NLR::NeuronIndex( 0, 0 ), 0 );
-        nlr.setNeuronVariable( NLR::NeuronIndex( 0, 1 ), 1 );
-
-        nlr.setNeuronVariable( NLR::NeuronIndex( 1, 0 ), 2 );
-        nlr.setNeuronVariable( NLR::NeuronIndex( 1, 1 ), 3 );
-
-        nlr.setNeuronVariable( NLR::NeuronIndex( 2, 0 ), 4 );
-        nlr.setNeuronVariable( NLR::NeuronIndex( 2, 1 ), 5 );
-
-        nlr.setNeuronVariable( NLR::NeuronIndex( 3, 0 ), 6 );
-        nlr.setNeuronVariable( NLR::NeuronIndex( 3, 1 ), 7 );
-
-        nlr.setNeuronVariable( NLR::NeuronIndex( 4, 0 ), 8 );
-        nlr.setNeuronVariable( NLR::NeuronIndex( 4, 1 ), 9 );
-
-        nlr.setNeuronVariable( NLR::NeuronIndex( 5, 0 ), 10 );
-
-        // Very loose bounds for neurons except inputs
-        double large = 1000000;
-
-        tableau.getBoundManager().initialize( 11 );
-        tableau.setLowerBound( 2, -large );
-        tableau.setUpperBound( 2, large );
-        tableau.setLowerBound( 3, -large );
-        tableau.setUpperBound( 3, large );
-        tableau.setLowerBound( 4, -large );
-        tableau.setUpperBound( 4, large );
-        tableau.setLowerBound( 5, -large );
-        tableau.setUpperBound( 5, large );
-        tableau.setLowerBound( 6, -large );
-        tableau.setUpperBound( 6, large );
-        tableau.setLowerBound( 7, -large );
-        tableau.setUpperBound( 7, large );
-        tableau.setLowerBound( 8, -large );
-        tableau.setUpperBound( 8, large );
-        tableau.setLowerBound( 9, -large );
-        tableau.setUpperBound( 9, large );
-        tableau.setLowerBound( 10, -large );
-        tableau.setUpperBound( 10, large );
-    }
-
     void test_backward_abs_and_relu()
     {
         Options::get()->setString( Options::SYMBOLIC_BOUND_TIGHTENING_TYPE, "sbt" );
@@ -698,13 +602,8 @@ public:
         } );
 
         TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( newBounds );
+        TS_ASSERT_THROWS_NOTHING( bounds = removeRedundancies( newBounds ) );
         TS_ASSERT( boundsEqual( bounds, expectedBounds2 ) );
-
-        List<Map<NLR::NeuronIndex, unsigned>> infeasibleBranches( {} );
-        List<Map<NLR::NeuronIndex, unsigned>> expectedInfeasibleBranches( {} );
-        TS_ASSERT_THROWS_NOTHING( nlr.getInfeasibleBranches( infeasibleBranches ) );
-        TS_ASSERT( infeasibleBranchesEqual( infeasibleBranches, expectedInfeasibleBranches ) );
     }
 
     void test_backward_round_and_sign()
@@ -758,13 +657,8 @@ public:
         List<Tightening> expectedBounds2( {} );
 
         TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( newBounds );
+        TS_ASSERT_THROWS_NOTHING( bounds = removeRedundancies( newBounds ) );
         TS_ASSERT( boundsEqual( bounds, expectedBounds2 ) );
-
-        List<Map<NLR::NeuronIndex, unsigned>> infeasibleBranches( {} );
-        List<Map<NLR::NeuronIndex, unsigned>> expectedInfeasibleBranches( {} );
-        TS_ASSERT_THROWS_NOTHING( nlr.getInfeasibleBranches( infeasibleBranches ) );
-        TS_ASSERT( infeasibleBranchesEqual( infeasibleBranches, expectedInfeasibleBranches ) );
     }
 
     void test_backward_leaky_relu_and_sigmoid()
@@ -821,13 +715,8 @@ public:
         } );
 
         TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( newBounds );
+        TS_ASSERT_THROWS_NOTHING( bounds = removeRedundancies( newBounds ) );
         TS_ASSERT( boundsEqual( bounds, expectedBounds2 ) );
-
-        List<Map<NLR::NeuronIndex, unsigned>> infeasibleBranches( {} );
-        List<Map<NLR::NeuronIndex, unsigned>> expectedInfeasibleBranches( {} );
-        TS_ASSERT_THROWS_NOTHING( nlr.getInfeasibleBranches( infeasibleBranches ) );
-        TS_ASSERT( infeasibleBranchesEqual( infeasibleBranches, expectedInfeasibleBranches ) );
     }
 
     void test_backward_softmax_and_max()
@@ -879,13 +768,8 @@ public:
         List<Tightening> expectedBounds2( {} );
 
         TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( newBounds );
+        TS_ASSERT_THROWS_NOTHING( bounds = removeRedundancies( newBounds ) );
         TS_ASSERT( boundsEqual( bounds, expectedBounds2 ) );
-
-        List<Map<NLR::NeuronIndex, unsigned>> infeasibleBranches( {} );
-        List<Map<NLR::NeuronIndex, unsigned>> expectedInfeasibleBranches( {} );
-        TS_ASSERT_THROWS_NOTHING( nlr.getInfeasibleBranches( infeasibleBranches ) );
-        TS_ASSERT( infeasibleBranchesEqual( infeasibleBranches, expectedInfeasibleBranches ) );
     }
 
     void test_backward_relu_and_bilinear()
@@ -937,19 +821,14 @@ public:
         List<Tightening> expectedBounds2( {} );
 
         TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( newBounds );
+        TS_ASSERT_THROWS_NOTHING( bounds = removeRedundancies( newBounds ) );
         TS_ASSERT( boundsEqual( bounds, expectedBounds2 ) );
-
-        List<Map<NLR::NeuronIndex, unsigned>> infeasibleBranches( {} );
-        List<Map<NLR::NeuronIndex, unsigned>> expectedInfeasibleBranches( {} );
-        TS_ASSERT_THROWS_NOTHING( nlr.getInfeasibleBranches( infeasibleBranches ) );
-        TS_ASSERT( infeasibleBranchesEqual( infeasibleBranches, expectedInfeasibleBranches ) );
     }
 
-    void test_pmnr_invprop_abs_and_relu()
+    void test_pmnr_abs_and_relu()
     {
         Options::get()->setString( Options::SYMBOLIC_BOUND_TIGHTENING_TYPE, "sbt" );
-        Options::get()->setString( Options::MILP_SOLVER_BOUND_TIGHTENING_TYPE, "backward-invprop" );
+        Options::get()->setString( Options::MILP_SOLVER_BOUND_TIGHTENING_TYPE, "backward-pmnr" );
 
         NLR::NetworkLevelReasoner nlr;
         MockTableau tableau;
@@ -988,973 +867,7 @@ public:
         TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( bounds ) );
         TS_ASSERT( boundsEqual( bounds, expectedBounds ) );
 
-        // Invoke Invprop
-        TS_ASSERT_THROWS_NOTHING( updateTableau( tableau, bounds ) );
-        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
-        TS_ASSERT_THROWS_NOTHING( nlr.lpRelaxationPropagation() );
-
-        List<Tightening> expectedBounds2( {
-            Tightening( 10, 0, Tightening::LB ),
-            Tightening( 11, 0, Tightening::LB ),
-
-            Tightening( 12, 0, Tightening::LB ),
-            Tightening( 13, 0, Tightening::LB ),
-        } );
-
-        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( newBounds );
-        TS_ASSERT( boundsEqual( bounds, expectedBounds2 ) );
-
-        List<Map<NLR::NeuronIndex, unsigned>> infeasibleBranches( {} );
-        List<Map<NLR::NeuronIndex, unsigned>> expectedInfeasibleBranches( {} );
-        TS_ASSERT_THROWS_NOTHING( nlr.getInfeasibleBranches( infeasibleBranches ) );
-        TS_ASSERT( infeasibleBranchesEqual( infeasibleBranches, expectedInfeasibleBranches ) );
-    }
-
-    void test_pmnr_invprop_round_and_sign()
-    {
-        Options::get()->setString( Options::SYMBOLIC_BOUND_TIGHTENING_TYPE, "sbt" );
-        Options::get()->setString( Options::MILP_SOLVER_BOUND_TIGHTENING_TYPE, "backward-invprop" );
-
-        NLR::NetworkLevelReasoner nlr;
-        MockTableau tableau;
-        nlr.setTableau( &tableau );
-        populateNetworkWithRoundAndSign( nlr, tableau );
-
-        tableau.setLowerBound( 0, -1 );
-        tableau.setUpperBound( 0, 1 );
-        tableau.setLowerBound( 1, -1 );
-        tableau.setUpperBound( 1, 1 );
-
-        // Invoke DeepPoly
-        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
-        TS_ASSERT_THROWS_NOTHING( nlr.deepPolyPropagation() );
-
-        List<Tightening> expectedBounds( {
-            Tightening( 2, 0, Tightening::LB ),    Tightening( 2, 2, Tightening::UB ),
-            Tightening( 3, -5, Tightening::LB ),   Tightening( 3, 5, Tightening::UB ),
-            Tightening( 4, -1, Tightening::LB ),   Tightening( 4, 1, Tightening::UB ),
-
-            Tightening( 5, 0, Tightening::LB ),    Tightening( 5, 2, Tightening::UB ),
-            Tightening( 6, -5, Tightening::LB ),   Tightening( 6, 5, Tightening::UB ),
-            Tightening( 7, -1, Tightening::LB ),   Tightening( 7, 1, Tightening::UB ),
-
-            Tightening( 8, -6, Tightening::LB ),   Tightening( 8, 8, Tightening::UB ),
-            Tightening( 9, -5.5, Tightening::LB ), Tightening( 9, 7.5, Tightening::UB ),
-
-            Tightening( 10, -1, Tightening::LB ),  Tightening( 10, 1, Tightening::UB ),
-            Tightening( 11, -1, Tightening::LB ),  Tightening( 11, 1, Tightening::UB ),
-
-            Tightening( 12, -1, Tightening::LB ),  Tightening( 12, 1, Tightening::UB ),
-            Tightening( 13, -4, Tightening::LB ),  Tightening( 13, 4, Tightening::UB ),
-        } );
-
-        List<Tightening> bounds, newBounds;
-        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( bounds ) );
-        TS_ASSERT( boundsEqual( bounds, expectedBounds ) );
-
-        // Invoke Invprop
-        TS_ASSERT_THROWS_NOTHING( updateTableau( tableau, bounds ) );
-        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
-        TS_ASSERT_THROWS_NOTHING( nlr.lpRelaxationPropagation() );
-
-        List<Tightening> expectedBounds2( {
-            Tightening( 9, -4.75, Tightening::LB ),
-            Tightening( 9, 6.75, Tightening::UB ),
-
-            Tightening( 12, 1, Tightening::UB ),
-            Tightening( 13, 4, Tightening::UB ),
-        } );
-
-        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( newBounds );
-        TS_ASSERT( boundsEqual( bounds, expectedBounds2 ) );
-
-        List<Map<NLR::NeuronIndex, unsigned>> infeasibleBranches( {} );
-        List<Map<NLR::NeuronIndex, unsigned>> expectedInfeasibleBranches( {} );
-        TS_ASSERT_THROWS_NOTHING( nlr.getInfeasibleBranches( infeasibleBranches ) );
-        TS_ASSERT( infeasibleBranchesEqual( infeasibleBranches, expectedInfeasibleBranches ) );
-    }
-
-    void test_pmnr_invprop_leaky_relu_and_sigmoid()
-    {
-        Options::get()->setString( Options::SYMBOLIC_BOUND_TIGHTENING_TYPE, "sbt" );
-        Options::get()->setString( Options::MILP_SOLVER_BOUND_TIGHTENING_TYPE, "backward-invprop" );
-
-        NLR::NetworkLevelReasoner nlr;
-        MockTableau tableau;
-        nlr.setTableau( &tableau );
-        populateNetworkWithLeakyReluAndSigmoid( nlr, tableau );
-
-        tableau.setLowerBound( 0, -1 );
-        tableau.setUpperBound( 0, 1 );
-        tableau.setLowerBound( 1, -1 );
-        tableau.setUpperBound( 1, 1 );
-
-        // Invoke DeepPoly
-        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
-        TS_ASSERT_THROWS_NOTHING( nlr.deepPolyPropagation() );
-
-        List<Tightening> expectedBounds( {
-            Tightening( 2, 0, Tightening::LB ),       Tightening( 2, 2, Tightening::UB ),
-            Tightening( 3, -5, Tightening::LB ),      Tightening( 3, 5, Tightening::UB ),
-            Tightening( 4, -1, Tightening::LB ),      Tightening( 4, 1, Tightening::UB ),
-
-            Tightening( 5, 0, Tightening::LB ),       Tightening( 5, 2, Tightening::UB ),
-            Tightening( 6, -5, Tightening::LB ),      Tightening( 6, 5, Tightening::UB ),
-            Tightening( 7, -1, Tightening::LB ),      Tightening( 7, 1, Tightening::UB ),
-
-            Tightening( 8, -6, Tightening::LB ),      Tightening( 8, 8, Tightening::UB ),
-            Tightening( 9, -4, Tightening::LB ),      Tightening( 9, 6, Tightening::UB ),
-
-            Tightening( 10, 0.0025, Tightening::LB ), Tightening( 10, 0.9997, Tightening::UB ),
-            Tightening( 11, 0.0180, Tightening::LB ), Tightening( 11, 0.9975, Tightening::UB ),
-
-            Tightening( 12, 0.0025, Tightening::LB ), Tightening( 12, 0.9997, Tightening::UB ),
-            Tightening( 13, 0.0564, Tightening::LB ), Tightening( 13, 3.9922, Tightening::UB ),
-        } );
-
-        List<Tightening> bounds, newBounds;
-        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( bounds ) );
-        TS_ASSERT( boundsEqual( bounds, expectedBounds ) );
-
-        // Invoke Invprop
-        TS_ASSERT_THROWS_NOTHING( updateTableau( tableau, bounds ) );
-        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
-        TS_ASSERT_THROWS_NOTHING( nlr.lpRelaxationPropagation() );
-
-        List<Tightening> expectedBounds2( {
-            Tightening( 6, -0.5, Tightening::LB ),
-            Tightening( 7, -0.1, Tightening::LB ),
-            Tightening( 8, 7.1, Tightening::UB ),
-            Tightening( 8, -1.5, Tightening::LB ),
-            Tightening( 9, 5.1, Tightening::UB ),
-            Tightening( 9, -1.1, Tightening::LB ),
-            Tightening( 10, 0.0845, Tightening::LB ),
-            Tightening( 10, 0.9993, Tightening::UB ),
-            Tightening( 11, 0.2181, Tightening::LB ),
-            Tightening( 11, 0.9949, Tightening::UB ),
-            Tightening( 12, 0.0845, Tightening::LB ),
-            Tightening( 12, 0.9993, Tightening::UB ),
-            Tightening( 13, 0.7410, Tightening::LB ),
-            Tightening( 13, 3.9841, Tightening::UB ),
-        } );
-
-        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( newBounds );
-        TS_ASSERT( boundsEqual( bounds, expectedBounds2 ) );
-
-        List<Map<NLR::NeuronIndex, unsigned>> infeasibleBranches( {} );
-        List<Map<NLR::NeuronIndex, unsigned>> expectedInfeasibleBranches( {} );
-        TS_ASSERT_THROWS_NOTHING( nlr.getInfeasibleBranches( infeasibleBranches ) );
-        TS_ASSERT( infeasibleBranchesEqual( infeasibleBranches, expectedInfeasibleBranches ) );
-    }
-
-    void test_pmnr_invprop_softmax_and_max()
-    {
-        Options::get()->setString( Options::SYMBOLIC_BOUND_TIGHTENING_TYPE, "sbt" );
-        Options::get()->setString( Options::MILP_SOLVER_BOUND_TIGHTENING_TYPE, "backward-invprop" );
-
-        NLR::NetworkLevelReasoner nlr;
-        MockTableau tableau;
-        nlr.setTableau( &tableau );
-        populateNetworkWithSoftmaxAndMax( nlr, tableau );
-
-        tableau.setLowerBound( 0, -1 );
-        tableau.setUpperBound( 0, 1 );
-        tableau.setLowerBound( 1, -1 );
-        tableau.setUpperBound( 1, 1 );
-
-        // Invoke DeepPoly
-        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
-        TS_ASSERT_THROWS_NOTHING( nlr.deepPolyPropagation() );
-
-        List<Tightening> expectedBounds( {
-            Tightening( 2, 0, Tightening::LB ),        Tightening( 2, 2, Tightening::UB ),
-            Tightening( 3, -5, Tightening::LB ),       Tightening( 3, 5, Tightening::UB ),
-            Tightening( 4, -1, Tightening::LB ),       Tightening( 4, 1, Tightening::UB ),
-
-            Tightening( 5, 0.0066, Tightening::LB ),   Tightening( 5, 0.9517, Tightening::UB ),
-            Tightening( 6, 0.0007, Tightening::LB ),   Tightening( 6, 0.9909, Tightening::UB ),
-            Tightening( 7, 0.0024, Tightening::LB ),   Tightening( 7, 0.7297, Tightening::UB ),
-
-            Tightening( 8, -0.7225, Tightening::LB ),  Tightening( 8, 1.9403, Tightening::UB ),
-            Tightening( 9, 0.3192, Tightening::LB ),   Tightening( 9, 2.9819, Tightening::UB ),
-
-            Tightening( 10, 0.3192, Tightening::LB ),  Tightening( 10, 2.9819, Tightening::UB ),
-
-            Tightening( 11, -2.9819, Tightening::LB ), Tightening( 11, -0.3192, Tightening::UB ),
-        } );
-
-        List<Tightening> bounds, newBounds;
-        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( bounds ) );
-        TS_ASSERT( boundsEqual( bounds, expectedBounds ) );
-
-        // Invoke Invprop
-        TS_ASSERT_THROWS_NOTHING( updateTableau( tableau, bounds ) );
-        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
-        TS_ASSERT_THROWS_NOTHING( nlr.lpRelaxationPropagation() );
-
-        List<Tightening> expectedBounds2( {
-            Tightening( 8, -0.6812, Tightening::LB ),
-            Tightening( 8, 1.8414, Tightening::UB ),
-        } );
-
-        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( newBounds );
-        TS_ASSERT( boundsEqual( bounds, expectedBounds2 ) );
-
-        List<Map<NLR::NeuronIndex, unsigned>> infeasibleBranches( {} );
-        List<Map<NLR::NeuronIndex, unsigned>> expectedInfeasibleBranches( {} );
-        TS_ASSERT_THROWS_NOTHING( nlr.getInfeasibleBranches( infeasibleBranches ) );
-        TS_ASSERT( infeasibleBranchesEqual( infeasibleBranches, expectedInfeasibleBranches ) );
-    }
-
-    void test_pmnr_invprop_relu_and_bilinear()
-    {
-        Options::get()->setString( Options::SYMBOLIC_BOUND_TIGHTENING_TYPE, "sbt" );
-        Options::get()->setString( Options::MILP_SOLVER_BOUND_TIGHTENING_TYPE, "backward-invprop" );
-
-        NLR::NetworkLevelReasoner nlr;
-        MockTableau tableau;
-        nlr.setTableau( &tableau );
-        populateNetworkWithReluAndBilinear( nlr, tableau );
-
-        tableau.setLowerBound( 0, -1 );
-        tableau.setUpperBound( 0, 1 );
-        tableau.setLowerBound( 1, -1 );
-        tableau.setUpperBound( 1, 1 );
-
-        // Invoke DeepPoly
-        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
-        TS_ASSERT_THROWS_NOTHING( nlr.deepPolyPropagation() );
-
-        List<Tightening> expectedBounds( {
-            Tightening( 2, 0, Tightening::LB ),    Tightening( 2, 2, Tightening::UB ),
-            Tightening( 3, -5, Tightening::LB ),   Tightening( 3, 5, Tightening::UB ),
-            Tightening( 4, -1, Tightening::LB ),   Tightening( 4, 1, Tightening::UB ),
-
-            Tightening( 5, 0, Tightening::LB ),    Tightening( 5, 2, Tightening::UB ),
-            Tightening( 6, 0, Tightening::LB ),    Tightening( 6, 5, Tightening::UB ),
-            Tightening( 7, 0, Tightening::LB ),    Tightening( 7, 1, Tightening::UB ),
-
-            Tightening( 8, -1, Tightening::LB ),   Tightening( 8, 7, Tightening::UB ),
-            Tightening( 9, -1, Tightening::LB ),   Tightening( 9, 5, Tightening::UB ),
-
-            Tightening( 10, -7, Tightening::LB ),  Tightening( 10, 35, Tightening::UB ),
-
-            Tightening( 11, -35, Tightening::LB ), Tightening( 11, 7, Tightening::UB ),
-        } );
-
-        List<Tightening> bounds, newBounds;
-        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( bounds ) );
-        TS_ASSERT( boundsEqual( bounds, expectedBounds ) );
-
-        // Invoke Invprop
-        TS_ASSERT_THROWS_NOTHING( updateTableau( tableau, bounds ) );
-        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
-        TS_ASSERT_THROWS_NOTHING( nlr.lpRelaxationPropagation() );
-
-        List<Tightening> expectedBounds2( {} );
-
-        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( newBounds );
-        TS_ASSERT( boundsEqual( bounds, expectedBounds2 ) );
-
-        List<Map<NLR::NeuronIndex, unsigned>> infeasibleBranches( {} );
-        List<Map<NLR::NeuronIndex, unsigned>> expectedInfeasibleBranches( {} );
-        TS_ASSERT_THROWS_NOTHING( nlr.getInfeasibleBranches( infeasibleBranches ) );
-        TS_ASSERT( infeasibleBranchesEqual( infeasibleBranches, expectedInfeasibleBranches ) );
-    }
-
-    void test_pmnr_random_abs_and_relu()
-    {
-        Options::get()->setString( Options::SYMBOLIC_BOUND_TIGHTENING_TYPE, "sbt" );
-        Options::get()->setString( Options::MILP_SOLVER_BOUND_TIGHTENING_TYPE,
-                                   "backward-pmnr-random" );
-
-        NLR::NetworkLevelReasoner nlr;
-        MockTableau tableau;
-        nlr.setTableau( &tableau );
-        populateNetworkWithAbsAndRelu( nlr, tableau );
-
-        tableau.setLowerBound( 0, -1 );
-        tableau.setUpperBound( 0, 1 );
-        tableau.setLowerBound( 1, -1 );
-        tableau.setUpperBound( 1, 1 );
-
-        // Invoke DeepPoly
-        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
-        TS_ASSERT_THROWS_NOTHING( nlr.deepPolyPropagation() );
-
-        List<Tightening> expectedBounds( {
-            Tightening( 2, 0, Tightening::LB ),    Tightening( 2, 2, Tightening::UB ),
-            Tightening( 3, -5, Tightening::LB ),   Tightening( 3, 5, Tightening::UB ),
-            Tightening( 4, -1, Tightening::LB ),   Tightening( 4, 1, Tightening::UB ),
-
-            Tightening( 5, 0, Tightening::LB ),    Tightening( 5, 2, Tightening::UB ),
-            Tightening( 6, 0, Tightening::LB ),    Tightening( 6, 5, Tightening::UB ),
-            Tightening( 7, 0, Tightening::LB ),    Tightening( 7, 1, Tightening::UB ),
-
-            Tightening( 8, -1, Tightening::LB ),   Tightening( 8, 7, Tightening::UB ),
-            Tightening( 9, -5, Tightening::LB ),   Tightening( 9, 7, Tightening::UB ),
-
-            Tightening( 10, -1, Tightening::LB ),  Tightening( 10, 7, Tightening::UB ),
-            Tightening( 11, -5, Tightening::LB ),  Tightening( 11, 7, Tightening::UB ),
-
-            Tightening( 12, -1, Tightening::LB ),  Tightening( 12, 7, Tightening::UB ),
-            Tightening( 13, -14, Tightening::LB ), Tightening( 13, 26.25, Tightening::UB ),
-        } );
-
-        List<Tightening> bounds, newBounds;
-        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( bounds ) );
-        TS_ASSERT( boundsEqual( bounds, expectedBounds ) );
-
-        // Invoke PMNR with random neuron selection
-        TS_ASSERT_THROWS_NOTHING( updateTableau( tableau, bounds ) );
-        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
-        TS_ASSERT_THROWS_NOTHING( nlr.lpRelaxationPropagation() );
-
-        List<Tightening> expectedBounds2( {
-            Tightening( 10, 0, Tightening::LB ),
-            Tightening( 11, 0, Tightening::LB ),
-
-            Tightening( 12, 0, Tightening::LB ),
-            Tightening( 13, 0, Tightening::LB ),
-        } );
-
-        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( newBounds );
-        TS_ASSERT( boundsEqual( bounds, expectedBounds2 ) );
-
-        List<Map<NLR::NeuronIndex, unsigned>> infeasibleBranches( {} );
-        List<Map<NLR::NeuronIndex, unsigned>> expectedInfeasibleBranches( {} );
-        TS_ASSERT_THROWS_NOTHING( nlr.getInfeasibleBranches( infeasibleBranches ) );
-        TS_ASSERT( infeasibleBranchesEqual( infeasibleBranches, expectedInfeasibleBranches ) );
-    }
-
-    void test_pmnr_random_round_and_sign()
-    {
-        Options::get()->setString( Options::SYMBOLIC_BOUND_TIGHTENING_TYPE, "sbt" );
-        Options::get()->setString( Options::MILP_SOLVER_BOUND_TIGHTENING_TYPE,
-                                   "backward-pmnr-random" );
-
-        NLR::NetworkLevelReasoner nlr;
-        MockTableau tableau;
-        nlr.setTableau( &tableau );
-        populateNetworkWithRoundAndSign( nlr, tableau );
-
-        tableau.setLowerBound( 0, -1 );
-        tableau.setUpperBound( 0, 1 );
-        tableau.setLowerBound( 1, -1 );
-        tableau.setUpperBound( 1, 1 );
-
-        // Invoke DeepPoly
-        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
-        TS_ASSERT_THROWS_NOTHING( nlr.deepPolyPropagation() );
-
-        List<Tightening> expectedBounds( {
-            Tightening( 2, 0, Tightening::LB ),    Tightening( 2, 2, Tightening::UB ),
-            Tightening( 3, -5, Tightening::LB ),   Tightening( 3, 5, Tightening::UB ),
-            Tightening( 4, -1, Tightening::LB ),   Tightening( 4, 1, Tightening::UB ),
-
-            Tightening( 5, 0, Tightening::LB ),    Tightening( 5, 2, Tightening::UB ),
-            Tightening( 6, -5, Tightening::LB ),   Tightening( 6, 5, Tightening::UB ),
-            Tightening( 7, -1, Tightening::LB ),   Tightening( 7, 1, Tightening::UB ),
-
-            Tightening( 8, -6, Tightening::LB ),   Tightening( 8, 8, Tightening::UB ),
-            Tightening( 9, -5.5, Tightening::LB ), Tightening( 9, 7.5, Tightening::UB ),
-
-            Tightening( 10, -1, Tightening::LB ),  Tightening( 10, 1, Tightening::UB ),
-            Tightening( 11, -1, Tightening::LB ),  Tightening( 11, 1, Tightening::UB ),
-
-            Tightening( 12, -1, Tightening::LB ),  Tightening( 12, 1, Tightening::UB ),
-            Tightening( 13, -4, Tightening::LB ),  Tightening( 13, 4, Tightening::UB ),
-        } );
-
-        List<Tightening> bounds, newBounds;
-        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( bounds ) );
-        TS_ASSERT( boundsEqual( bounds, expectedBounds ) );
-
-        // Invoke PMNR with random neuron selection
-        TS_ASSERT_THROWS_NOTHING( updateTableau( tableau, bounds ) );
-        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
-        TS_ASSERT_THROWS_NOTHING( nlr.lpRelaxationPropagation() );
-
-        List<Tightening> expectedBounds2( {
-            Tightening( 9, -4.75, Tightening::LB ),
-            Tightening( 9, 6.75, Tightening::UB ),
-        } );
-
-        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( newBounds );
-        TS_ASSERT( boundsEqual( bounds, expectedBounds2 ) );
-
-        List<Map<NLR::NeuronIndex, unsigned>> infeasibleBranches( {} );
-        List<Map<NLR::NeuronIndex, unsigned>> expectedInfeasibleBranches( {} );
-        TS_ASSERT_THROWS_NOTHING( nlr.getInfeasibleBranches( infeasibleBranches ) );
-        TS_ASSERT( infeasibleBranchesEqual( infeasibleBranches, expectedInfeasibleBranches ) );
-    }
-
-    void test_pmnr_random_leaky_relu_and_sigmoid()
-    {
-        Options::get()->setString( Options::SYMBOLIC_BOUND_TIGHTENING_TYPE, "sbt" );
-        Options::get()->setString( Options::MILP_SOLVER_BOUND_TIGHTENING_TYPE,
-                                   "backward-pmnr-random" );
-
-        NLR::NetworkLevelReasoner nlr;
-        MockTableau tableau;
-        nlr.setTableau( &tableau );
-        populateNetworkWithLeakyReluAndSigmoid( nlr, tableau );
-
-        tableau.setLowerBound( 0, -1 );
-        tableau.setUpperBound( 0, 1 );
-        tableau.setLowerBound( 1, -1 );
-        tableau.setUpperBound( 1, 1 );
-
-        // Invoke DeepPoly
-        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
-        TS_ASSERT_THROWS_NOTHING( nlr.deepPolyPropagation() );
-
-        List<Tightening> expectedBounds( {
-            Tightening( 2, 0, Tightening::LB ),       Tightening( 2, 2, Tightening::UB ),
-            Tightening( 3, -5, Tightening::LB ),      Tightening( 3, 5, Tightening::UB ),
-            Tightening( 4, -1, Tightening::LB ),      Tightening( 4, 1, Tightening::UB ),
-
-            Tightening( 5, 0, Tightening::LB ),       Tightening( 5, 2, Tightening::UB ),
-            Tightening( 6, -5, Tightening::LB ),      Tightening( 6, 5, Tightening::UB ),
-            Tightening( 7, -1, Tightening::LB ),      Tightening( 7, 1, Tightening::UB ),
-
-            Tightening( 8, -6, Tightening::LB ),      Tightening( 8, 8, Tightening::UB ),
-            Tightening( 9, -4, Tightening::LB ),      Tightening( 9, 6, Tightening::UB ),
-
-            Tightening( 10, 0.0025, Tightening::LB ), Tightening( 10, 0.9997, Tightening::UB ),
-            Tightening( 11, 0.0180, Tightening::LB ), Tightening( 11, 0.9975, Tightening::UB ),
-
-            Tightening( 12, 0.0025, Tightening::LB ), Tightening( 12, 0.9997, Tightening::UB ),
-            Tightening( 13, 0.0564, Tightening::LB ), Tightening( 13, 3.9922, Tightening::UB ),
-        } );
-
-        List<Tightening> bounds, newBounds;
-        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( bounds ) );
-        TS_ASSERT( boundsEqual( bounds, expectedBounds ) );
-
-        // Invoke PMNR with random neuron selection
-        TS_ASSERT_THROWS_NOTHING( updateTableau( tableau, bounds ) );
-        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
-        TS_ASSERT_THROWS_NOTHING( nlr.lpRelaxationPropagation() );
-
-        List<Tightening> expectedBounds2( {
-            Tightening( 6, -0.5, Tightening::LB ),
-            Tightening( 7, -0.1, Tightening::LB ),
-            Tightening( 8, -1.5, Tightening::LB ),
-            Tightening( 8, 7.1, Tightening::UB ),
-            Tightening( 9, -1.1, Tightening::LB ),
-            Tightening( 9, 5.1, Tightening::UB ),
-            Tightening( 10, 0.0266, Tightening::LB ),
-            Tightening( 10, 0.9995, Tightening::UB ),
-            Tightening( 11, 0.1679, Tightening::LB ),
-            Tightening( 11, 0.9960, Tightening::UB ),
-            Tightening( 12, 0.0266, Tightening::LB ),
-            Tightening( 12, 0.9995, Tightening::UB ),
-            Tightening( 13, 0.5302, Tightening::LB ),
-            Tightening( 13, 3.9875, Tightening::UB ),
-        } );
-
-        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( newBounds );
-        TS_ASSERT( boundsEqual( bounds, expectedBounds2 ) );
-
-        List<Map<NLR::NeuronIndex, unsigned>> infeasibleBranches( {} );
-        List<Map<NLR::NeuronIndex, unsigned>> expectedInfeasibleBranches( {} );
-        TS_ASSERT_THROWS_NOTHING( nlr.getInfeasibleBranches( infeasibleBranches ) );
-        TS_ASSERT( infeasibleBranchesEqual( infeasibleBranches, expectedInfeasibleBranches ) );
-    }
-
-    void test_pmnr_random_softmax_and_max()
-    {
-        Options::get()->setString( Options::SYMBOLIC_BOUND_TIGHTENING_TYPE, "sbt" );
-        Options::get()->setString( Options::MILP_SOLVER_BOUND_TIGHTENING_TYPE,
-                                   "backward-pmnr-random" );
-
-        NLR::NetworkLevelReasoner nlr;
-        MockTableau tableau;
-        nlr.setTableau( &tableau );
-        populateNetworkWithSoftmaxAndMax( nlr, tableau );
-
-        tableau.setLowerBound( 0, -1 );
-        tableau.setUpperBound( 0, 1 );
-        tableau.setLowerBound( 1, -1 );
-        tableau.setUpperBound( 1, 1 );
-
-        // Invoke DeepPoly
-        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
-        TS_ASSERT_THROWS_NOTHING( nlr.deepPolyPropagation() );
-
-        List<Tightening> expectedBounds( {
-            Tightening( 2, 0, Tightening::LB ),        Tightening( 2, 2, Tightening::UB ),
-            Tightening( 3, -5, Tightening::LB ),       Tightening( 3, 5, Tightening::UB ),
-            Tightening( 4, -1, Tightening::LB ),       Tightening( 4, 1, Tightening::UB ),
-
-            Tightening( 5, 0.0066, Tightening::LB ),   Tightening( 5, 0.9517, Tightening::UB ),
-            Tightening( 6, 0.0007, Tightening::LB ),   Tightening( 6, 0.9909, Tightening::UB ),
-            Tightening( 7, 0.0024, Tightening::LB ),   Tightening( 7, 0.7297, Tightening::UB ),
-
-            Tightening( 8, -0.7225, Tightening::LB ),  Tightening( 8, 1.9403, Tightening::UB ),
-            Tightening( 9, 0.3192, Tightening::LB ),   Tightening( 9, 2.9819, Tightening::UB ),
-
-            Tightening( 10, 0.3192, Tightening::LB ),  Tightening( 10, 2.9819, Tightening::UB ),
-
-            Tightening( 11, -2.9819, Tightening::LB ), Tightening( 11, -0.3192, Tightening::UB ),
-        } );
-
-        List<Tightening> bounds, newBounds;
-        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( bounds ) );
-        TS_ASSERT( boundsEqual( bounds, expectedBounds ) );
-
-        // Invoke PMNR with random neuron selection
-        TS_ASSERT_THROWS_NOTHING( updateTableau( tableau, bounds ) );
-        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
-        TS_ASSERT_THROWS_NOTHING( nlr.lpRelaxationPropagation() );
-
-        List<Tightening> expectedBounds2( {
-            Tightening( 8, -0.6812, Tightening::LB ),
-            Tightening( 8, 1.8409, Tightening::UB ),
-        } );
-
-        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( newBounds );
-        TS_ASSERT( boundsEqual( bounds, expectedBounds2 ) );
-
-        List<Map<NLR::NeuronIndex, unsigned>> infeasibleBranches( {} );
-        List<Map<NLR::NeuronIndex, unsigned>> expectedInfeasibleBranches( {} );
-        TS_ASSERT_THROWS_NOTHING( nlr.getInfeasibleBranches( infeasibleBranches ) );
-        TS_ASSERT( infeasibleBranchesEqual( infeasibleBranches, expectedInfeasibleBranches ) );
-    }
-
-    void test_pmnr_random_relu_and_bilinear()
-    {
-        Options::get()->setString( Options::SYMBOLIC_BOUND_TIGHTENING_TYPE, "sbt" );
-        Options::get()->setString( Options::MILP_SOLVER_BOUND_TIGHTENING_TYPE,
-                                   "backward-pmnr-random" );
-
-        NLR::NetworkLevelReasoner nlr;
-        MockTableau tableau;
-        nlr.setTableau( &tableau );
-        populateNetworkWithReluAndBilinear( nlr, tableau );
-
-        tableau.setLowerBound( 0, -1 );
-        tableau.setUpperBound( 0, 1 );
-        tableau.setLowerBound( 1, -1 );
-        tableau.setUpperBound( 1, 1 );
-
-        // Invoke DeepPoly
-        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
-        TS_ASSERT_THROWS_NOTHING( nlr.deepPolyPropagation() );
-
-        List<Tightening> expectedBounds( {
-            Tightening( 2, 0, Tightening::LB ),    Tightening( 2, 2, Tightening::UB ),
-            Tightening( 3, -5, Tightening::LB ),   Tightening( 3, 5, Tightening::UB ),
-            Tightening( 4, -1, Tightening::LB ),   Tightening( 4, 1, Tightening::UB ),
-
-            Tightening( 5, 0, Tightening::LB ),    Tightening( 5, 2, Tightening::UB ),
-            Tightening( 6, 0, Tightening::LB ),    Tightening( 6, 5, Tightening::UB ),
-            Tightening( 7, 0, Tightening::LB ),    Tightening( 7, 1, Tightening::UB ),
-
-            Tightening( 8, -1, Tightening::LB ),   Tightening( 8, 7, Tightening::UB ),
-            Tightening( 9, -1, Tightening::LB ),   Tightening( 9, 5, Tightening::UB ),
-
-            Tightening( 10, -7, Tightening::LB ),  Tightening( 10, 35, Tightening::UB ),
-
-            Tightening( 11, -35, Tightening::LB ), Tightening( 11, 7, Tightening::UB ),
-        } );
-
-        List<Tightening> bounds, newBounds;
-        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( bounds ) );
-        TS_ASSERT( boundsEqual( bounds, expectedBounds ) );
-
-        // Invoke PMNR with random neuron selection
-        TS_ASSERT_THROWS_NOTHING( updateTableau( tableau, bounds ) );
-        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
-        TS_ASSERT_THROWS_NOTHING( nlr.lpRelaxationPropagation() );
-
-        List<Tightening> expectedBounds2( {} );
-
-        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( newBounds );
-        TS_ASSERT( boundsEqual( bounds, expectedBounds2 ) );
-
-        List<Map<NLR::NeuronIndex, unsigned>> infeasibleBranches( {} );
-        List<Map<NLR::NeuronIndex, unsigned>> expectedInfeasibleBranches( {} );
-        TS_ASSERT_THROWS_NOTHING( nlr.getInfeasibleBranches( infeasibleBranches ) );
-        TS_ASSERT( infeasibleBranchesEqual( infeasibleBranches, expectedInfeasibleBranches ) );
-    }
-
-    void test_pmnr_gradient_abs_and_relu()
-    {
-        Options::get()->setString( Options::SYMBOLIC_BOUND_TIGHTENING_TYPE, "sbt" );
-        Options::get()->setString( Options::MILP_SOLVER_BOUND_TIGHTENING_TYPE,
-                                   "backward-pmnr-gradient" );
-
-        NLR::NetworkLevelReasoner nlr;
-        MockTableau tableau;
-        nlr.setTableau( &tableau );
-        populateNetworkWithAbsAndRelu( nlr, tableau );
-
-        tableau.setLowerBound( 0, -1 );
-        tableau.setUpperBound( 0, 1 );
-        tableau.setLowerBound( 1, -1 );
-        tableau.setUpperBound( 1, 1 );
-
-        // Invoke DeepPoly
-        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
-        TS_ASSERT_THROWS_NOTHING( nlr.deepPolyPropagation() );
-
-        List<Tightening> expectedBounds( {
-            Tightening( 2, 0, Tightening::LB ),    Tightening( 2, 2, Tightening::UB ),
-            Tightening( 3, -5, Tightening::LB ),   Tightening( 3, 5, Tightening::UB ),
-            Tightening( 4, -1, Tightening::LB ),   Tightening( 4, 1, Tightening::UB ),
-
-            Tightening( 5, 0, Tightening::LB ),    Tightening( 5, 2, Tightening::UB ),
-            Tightening( 6, 0, Tightening::LB ),    Tightening( 6, 5, Tightening::UB ),
-            Tightening( 7, 0, Tightening::LB ),    Tightening( 7, 1, Tightening::UB ),
-
-            Tightening( 8, -1, Tightening::LB ),   Tightening( 8, 7, Tightening::UB ),
-            Tightening( 9, -5, Tightening::LB ),   Tightening( 9, 7, Tightening::UB ),
-
-            Tightening( 10, -1, Tightening::LB ),  Tightening( 10, 7, Tightening::UB ),
-            Tightening( 11, -5, Tightening::LB ),  Tightening( 11, 7, Tightening::UB ),
-
-            Tightening( 12, -1, Tightening::LB ),  Tightening( 12, 7, Tightening::UB ),
-            Tightening( 13, -14, Tightening::LB ), Tightening( 13, 26.25, Tightening::UB ),
-        } );
-
-        List<Tightening> bounds, newBounds;
-        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( bounds ) );
-        TS_ASSERT( boundsEqual( bounds, expectedBounds ) );
-
-        // Invoke PMNR with gradient-based heuristic for neuron selection
-        TS_ASSERT_THROWS_NOTHING( updateTableau( tableau, bounds ) );
-        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
-        TS_ASSERT_THROWS_NOTHING( nlr.lpRelaxationPropagation() );
-
-        List<Tightening> expectedBounds2( {
-            Tightening( 10, 0, Tightening::LB ),
-            Tightening( 11, 0, Tightening::LB ),
-
-            Tightening( 12, 0, Tightening::LB ),
-            Tightening( 13, 0, Tightening::LB ),
-        } );
-
-        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( newBounds );
-        TS_ASSERT( boundsEqual( bounds, expectedBounds2 ) );
-
-        List<Map<NLR::NeuronIndex, unsigned>> infeasibleBranches( {} );
-        List<Map<NLR::NeuronIndex, unsigned>> expectedInfeasibleBranches( {} );
-        TS_ASSERT_THROWS_NOTHING( nlr.getInfeasibleBranches( infeasibleBranches ) );
-        TS_ASSERT( infeasibleBranchesEqual( infeasibleBranches, expectedInfeasibleBranches ) );
-    }
-
-    void test_pmnr_gradient_round_and_sign()
-    {
-        Options::get()->setString( Options::SYMBOLIC_BOUND_TIGHTENING_TYPE, "sbt" );
-        Options::get()->setString( Options::MILP_SOLVER_BOUND_TIGHTENING_TYPE,
-                                   "backward-pmnr-gradient" );
-
-        NLR::NetworkLevelReasoner nlr;
-        MockTableau tableau;
-        nlr.setTableau( &tableau );
-        populateNetworkWithRoundAndSign( nlr, tableau );
-
-        tableau.setLowerBound( 0, -1 );
-        tableau.setUpperBound( 0, 1 );
-        tableau.setLowerBound( 1, -1 );
-        tableau.setUpperBound( 1, 1 );
-
-        // Invoke DeepPoly
-        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
-        TS_ASSERT_THROWS_NOTHING( nlr.deepPolyPropagation() );
-
-        List<Tightening> expectedBounds( {
-            Tightening( 2, 0, Tightening::LB ),    Tightening( 2, 2, Tightening::UB ),
-            Tightening( 3, -5, Tightening::LB ),   Tightening( 3, 5, Tightening::UB ),
-            Tightening( 4, -1, Tightening::LB ),   Tightening( 4, 1, Tightening::UB ),
-
-            Tightening( 5, 0, Tightening::LB ),    Tightening( 5, 2, Tightening::UB ),
-            Tightening( 6, -5, Tightening::LB ),   Tightening( 6, 5, Tightening::UB ),
-            Tightening( 7, -1, Tightening::LB ),   Tightening( 7, 1, Tightening::UB ),
-
-            Tightening( 8, -6, Tightening::LB ),   Tightening( 8, 8, Tightening::UB ),
-            Tightening( 9, -5.5, Tightening::LB ), Tightening( 9, 7.5, Tightening::UB ),
-
-            Tightening( 10, -1, Tightening::LB ),  Tightening( 10, 1, Tightening::UB ),
-            Tightening( 11, -1, Tightening::LB ),  Tightening( 11, 1, Tightening::UB ),
-
-            Tightening( 12, -1, Tightening::LB ),  Tightening( 12, 1, Tightening::UB ),
-            Tightening( 13, -4, Tightening::LB ),  Tightening( 13, 4, Tightening::UB ),
-        } );
-
-        List<Tightening> bounds, newBounds;
-        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( bounds ) );
-        TS_ASSERT( boundsEqual( bounds, expectedBounds ) );
-
-        // Invoke PMNR with gradient-based heuristic for neuron selection
-        TS_ASSERT_THROWS_NOTHING( updateTableau( tableau, bounds ) );
-        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
-        TS_ASSERT_THROWS_NOTHING( nlr.lpRelaxationPropagation() );
-
-        List<Tightening> expectedBounds2(
-            { Tightening( 9, -4.75, Tightening::LB ), Tightening( 9, 6.75, Tightening::UB ) } );
-
-        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( newBounds );
-        TS_ASSERT( boundsEqual( bounds, expectedBounds2 ) );
-
-        List<Map<NLR::NeuronIndex, unsigned>> infeasibleBranches( {} );
-        List<Map<NLR::NeuronIndex, unsigned>> expectedInfeasibleBranches( {} );
-        TS_ASSERT_THROWS_NOTHING( nlr.getInfeasibleBranches( infeasibleBranches ) );
-        TS_ASSERT( infeasibleBranchesEqual( infeasibleBranches, expectedInfeasibleBranches ) );
-    }
-
-    void test_pmnr_gradient_leaky_relu_and_sigmoid()
-    {
-        Options::get()->setString( Options::SYMBOLIC_BOUND_TIGHTENING_TYPE, "sbt" );
-        Options::get()->setString( Options::MILP_SOLVER_BOUND_TIGHTENING_TYPE,
-                                   "backward-pmnr-gradient" );
-
-        NLR::NetworkLevelReasoner nlr;
-        MockTableau tableau;
-        nlr.setTableau( &tableau );
-        populateNetworkWithLeakyReluAndSigmoid( nlr, tableau );
-
-        tableau.setLowerBound( 0, -1 );
-        tableau.setUpperBound( 0, 1 );
-        tableau.setLowerBound( 1, -1 );
-        tableau.setUpperBound( 1, 1 );
-
-        // Invoke DeepPoly
-        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
-        TS_ASSERT_THROWS_NOTHING( nlr.deepPolyPropagation() );
-
-        List<Tightening> expectedBounds( {
-            Tightening( 2, 0, Tightening::LB ),       Tightening( 2, 2, Tightening::UB ),
-            Tightening( 3, -5, Tightening::LB ),      Tightening( 3, 5, Tightening::UB ),
-            Tightening( 4, -1, Tightening::LB ),      Tightening( 4, 1, Tightening::UB ),
-
-            Tightening( 5, 0, Tightening::LB ),       Tightening( 5, 2, Tightening::UB ),
-            Tightening( 6, -5, Tightening::LB ),      Tightening( 6, 5, Tightening::UB ),
-            Tightening( 7, -1, Tightening::LB ),      Tightening( 7, 1, Tightening::UB ),
-
-            Tightening( 8, -6, Tightening::LB ),      Tightening( 8, 8, Tightening::UB ),
-            Tightening( 9, -4, Tightening::LB ),      Tightening( 9, 6, Tightening::UB ),
-
-            Tightening( 10, 0.0025, Tightening::LB ), Tightening( 10, 0.9997, Tightening::UB ),
-            Tightening( 11, 0.0180, Tightening::LB ), Tightening( 11, 0.9975, Tightening::UB ),
-
-            Tightening( 12, 0.0025, Tightening::LB ), Tightening( 12, 0.9997, Tightening::UB ),
-            Tightening( 13, 0.0564, Tightening::LB ), Tightening( 13, 3.9922, Tightening::UB ),
-        } );
-
-        List<Tightening> bounds, newBounds;
-        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( bounds ) );
-        TS_ASSERT( boundsEqual( bounds, expectedBounds ) );
-
-        // Invoke PMNR with gradient-based heuristic for neuron selection
-        TS_ASSERT_THROWS_NOTHING( updateTableau( tableau, bounds ) );
-        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
-        TS_ASSERT_THROWS_NOTHING( nlr.lpRelaxationPropagation() );
-
-        List<Tightening> expectedBounds2( {
-            Tightening( 6, -0.5, Tightening::LB ),
-            Tightening( 7, -0.1, Tightening::LB ),
-            Tightening( 8, -1.5, Tightening::LB ),
-            Tightening( 8, 7.1, Tightening::UB ),
-            Tightening( 9, -1.1, Tightening::LB ),
-            Tightening( 9, 5.1, Tightening::UB ),
-            Tightening( 10, 0.0230, Tightening::LB ),
-            Tightening( 10, 0.9995, Tightening::UB ),
-            Tightening( 11, 0.1483, Tightening::LB ),
-            Tightening( 11, 0.9961, Tightening::UB ),
-            Tightening( 12, 0.0230, Tightening::LB ),
-            Tightening( 12, 0.9995, Tightening::UB ),
-            Tightening( 13, 0.4680, Tightening::LB ),
-            Tightening( 13, 3.9879, Tightening::UB ),
-        } );
-
-        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( newBounds );
-        TS_ASSERT( boundsEqual( bounds, expectedBounds2 ) );
-
-        List<Map<NLR::NeuronIndex, unsigned>> infeasibleBranches( {} );
-        List<Map<NLR::NeuronIndex, unsigned>> expectedInfeasibleBranches( {} );
-        TS_ASSERT_THROWS_NOTHING( nlr.getInfeasibleBranches( infeasibleBranches ) );
-        TS_ASSERT( infeasibleBranchesEqual( infeasibleBranches, expectedInfeasibleBranches ) );
-    }
-
-    void test_pmnr_gradient_softmax_and_max()
-    {
-        Options::get()->setString( Options::SYMBOLIC_BOUND_TIGHTENING_TYPE, "sbt" );
-        Options::get()->setString( Options::MILP_SOLVER_BOUND_TIGHTENING_TYPE,
-                                   "backward-pmnr-gradient" );
-
-        NLR::NetworkLevelReasoner nlr;
-        MockTableau tableau;
-        nlr.setTableau( &tableau );
-        populateNetworkWithSoftmaxAndMax( nlr, tableau );
-
-        tableau.setLowerBound( 0, -1 );
-        tableau.setUpperBound( 0, 1 );
-        tableau.setLowerBound( 1, -1 );
-        tableau.setUpperBound( 1, 1 );
-
-        // Invoke DeepPoly
-        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
-        TS_ASSERT_THROWS_NOTHING( nlr.deepPolyPropagation() );
-
-        List<Tightening> expectedBounds( {
-            Tightening( 2, 0, Tightening::LB ),        Tightening( 2, 2, Tightening::UB ),
-            Tightening( 3, -5, Tightening::LB ),       Tightening( 3, 5, Tightening::UB ),
-            Tightening( 4, -1, Tightening::LB ),       Tightening( 4, 1, Tightening::UB ),
-
-            Tightening( 5, 0.0066, Tightening::LB ),   Tightening( 5, 0.9517, Tightening::UB ),
-            Tightening( 6, 0.0007, Tightening::LB ),   Tightening( 6, 0.9909, Tightening::UB ),
-            Tightening( 7, 0.0024, Tightening::LB ),   Tightening( 7, 0.7297, Tightening::UB ),
-
-            Tightening( 8, -0.7225, Tightening::LB ),  Tightening( 8, 1.9403, Tightening::UB ),
-            Tightening( 9, 0.3192, Tightening::LB ),   Tightening( 9, 2.9819, Tightening::UB ),
-
-            Tightening( 10, 0.3192, Tightening::LB ),  Tightening( 10, 2.9819, Tightening::UB ),
-
-            Tightening( 11, -2.9819, Tightening::LB ), Tightening( 11, -0.3192, Tightening::UB ),
-        } );
-
-        List<Tightening> bounds, newBounds;
-        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( bounds ) );
-        TS_ASSERT( boundsEqual( bounds, expectedBounds ) );
-
-        // Invoke PMNR with gradient-based heuristic for neuron selection
-        TS_ASSERT_THROWS_NOTHING( updateTableau( tableau, bounds ) );
-        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
-        TS_ASSERT_THROWS_NOTHING( nlr.lpRelaxationPropagation() );
-
-        List<Tightening> expectedBounds2( {
-            Tightening( 8, -0.6812, Tightening::LB ),
-            Tightening( 8, 1.8414, Tightening::UB ),
-        } );
-
-        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( newBounds );
-        TS_ASSERT( boundsEqual( bounds, expectedBounds2 ) );
-
-        List<Map<NLR::NeuronIndex, unsigned>> infeasibleBranches( {} );
-        List<Map<NLR::NeuronIndex, unsigned>> expectedInfeasibleBranches( {} );
-        TS_ASSERT_THROWS_NOTHING( nlr.getInfeasibleBranches( infeasibleBranches ) );
-        TS_ASSERT( infeasibleBranchesEqual( infeasibleBranches, expectedInfeasibleBranches ) );
-    }
-
-    void test_pmnr_gradient_relu_and_bilinear()
-    {
-        Options::get()->setString( Options::SYMBOLIC_BOUND_TIGHTENING_TYPE, "sbt" );
-        Options::get()->setString( Options::MILP_SOLVER_BOUND_TIGHTENING_TYPE,
-                                   "backward-pmnr-gradient" );
-
-        NLR::NetworkLevelReasoner nlr;
-        MockTableau tableau;
-        nlr.setTableau( &tableau );
-        populateNetworkWithReluAndBilinear( nlr, tableau );
-
-        tableau.setLowerBound( 0, -1 );
-        tableau.setUpperBound( 0, 1 );
-        tableau.setLowerBound( 1, -1 );
-        tableau.setUpperBound( 1, 1 );
-
-        // Invoke DeepPoly
-        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
-        TS_ASSERT_THROWS_NOTHING( nlr.deepPolyPropagation() );
-
-        List<Tightening> expectedBounds( {
-            Tightening( 2, 0, Tightening::LB ),    Tightening( 2, 2, Tightening::UB ),
-            Tightening( 3, -5, Tightening::LB ),   Tightening( 3, 5, Tightening::UB ),
-            Tightening( 4, -1, Tightening::LB ),   Tightening( 4, 1, Tightening::UB ),
-
-            Tightening( 5, 0, Tightening::LB ),    Tightening( 5, 2, Tightening::UB ),
-            Tightening( 6, 0, Tightening::LB ),    Tightening( 6, 5, Tightening::UB ),
-            Tightening( 7, 0, Tightening::LB ),    Tightening( 7, 1, Tightening::UB ),
-
-            Tightening( 8, -1, Tightening::LB ),   Tightening( 8, 7, Tightening::UB ),
-            Tightening( 9, -1, Tightening::LB ),   Tightening( 9, 5, Tightening::UB ),
-
-            Tightening( 10, -7, Tightening::LB ),  Tightening( 10, 35, Tightening::UB ),
-
-            Tightening( 11, -35, Tightening::LB ), Tightening( 11, 7, Tightening::UB ),
-        } );
-
-        List<Tightening> bounds, newBounds;
-        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( bounds ) );
-        TS_ASSERT( boundsEqual( bounds, expectedBounds ) );
-
-        // Invoke PMNR with gradient-based heuristic for neuron selection
-        TS_ASSERT_THROWS_NOTHING( updateTableau( tableau, bounds ) );
-        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
-        TS_ASSERT_THROWS_NOTHING( nlr.lpRelaxationPropagation() );
-
-        List<Tightening> expectedBounds2( {} );
-
-        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( newBounds );
-        TS_ASSERT( boundsEqual( bounds, expectedBounds2 ) );
-
-        List<Map<NLR::NeuronIndex, unsigned>> infeasibleBranches( {} );
-        List<Map<NLR::NeuronIndex, unsigned>> expectedInfeasibleBranches( {} );
-        TS_ASSERT_THROWS_NOTHING( nlr.getInfeasibleBranches( infeasibleBranches ) );
-        TS_ASSERT( infeasibleBranchesEqual( infeasibleBranches, expectedInfeasibleBranches ) );
-    }
-
-    void test_pmnr_bbps_abs_and_relu()
-    {
-        Options::get()->setString( Options::SYMBOLIC_BOUND_TIGHTENING_TYPE, "sbt" );
-        Options::get()->setString( Options::MILP_SOLVER_BOUND_TIGHTENING_TYPE,
-                                   "backward-pmnr-bbps" );
-
-        NLR::NetworkLevelReasoner nlr;
-        MockTableau tableau;
-        nlr.setTableau( &tableau );
-        populateNetworkWithAbsAndRelu( nlr, tableau );
-
-        tableau.setLowerBound( 0, -1 );
-        tableau.setUpperBound( 0, 1 );
-        tableau.setLowerBound( 1, -1 );
-        tableau.setUpperBound( 1, 1 );
-
-        // Invoke DeepPoly
-        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
-        TS_ASSERT_THROWS_NOTHING( nlr.deepPolyPropagation() );
-
-        List<Tightening> expectedBounds( {
-            Tightening( 2, 0, Tightening::LB ),    Tightening( 2, 2, Tightening::UB ),
-            Tightening( 3, -5, Tightening::LB ),   Tightening( 3, 5, Tightening::UB ),
-            Tightening( 4, -1, Tightening::LB ),   Tightening( 4, 1, Tightening::UB ),
-
-            Tightening( 5, 0, Tightening::LB ),    Tightening( 5, 2, Tightening::UB ),
-            Tightening( 6, 0, Tightening::LB ),    Tightening( 6, 5, Tightening::UB ),
-            Tightening( 7, 0, Tightening::LB ),    Tightening( 7, 1, Tightening::UB ),
-
-            Tightening( 8, -1, Tightening::LB ),   Tightening( 8, 7, Tightening::UB ),
-            Tightening( 9, -5, Tightening::LB ),   Tightening( 9, 7, Tightening::UB ),
-
-            Tightening( 10, -1, Tightening::LB ),  Tightening( 10, 7, Tightening::UB ),
-            Tightening( 11, -5, Tightening::LB ),  Tightening( 11, 7, Tightening::UB ),
-
-            Tightening( 12, -1, Tightening::LB ),  Tightening( 12, 7, Tightening::UB ),
-            Tightening( 13, -14, Tightening::LB ), Tightening( 13, 26.25, Tightening::UB ),
-        } );
-
-        List<Tightening> bounds, newBounds;
-        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( bounds ) );
-        TS_ASSERT( boundsEqual( bounds, expectedBounds ) );
-
-        // Invoke PMNR with BBPS-based heuristic for neuron selection
+        // Invoke PMNR for neuron selection.
         TS_ASSERT_THROWS_NOTHING( updateTableau( tableau, bounds ) );
         TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
         TS_ASSERT_THROWS_NOTHING( nlr.lpRelaxationPropagation() );
@@ -1969,7 +882,7 @@ public:
         } );
 
         TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( newBounds );
+        TS_ASSERT_THROWS_NOTHING( bounds = removeRedundancies( newBounds, bounds ) );
         TS_ASSERT( boundsEqual( bounds, expectedBounds2 ) );
 
         List<Map<NLR::NeuronIndex, unsigned>> infeasibleBranches( {} );
@@ -1978,11 +891,10 @@ public:
         TS_ASSERT( infeasibleBranchesEqual( infeasibleBranches, expectedInfeasibleBranches ) );
     }
 
-    void test_pmnr_bbps_round_and_sign()
+    void test_pmnr_round_and_sign()
     {
         Options::get()->setString( Options::SYMBOLIC_BOUND_TIGHTENING_TYPE, "sbt" );
-        Options::get()->setString( Options::MILP_SOLVER_BOUND_TIGHTENING_TYPE,
-                                   "backward-pmnr-bbps" );
+        Options::get()->setString( Options::MILP_SOLVER_BOUND_TIGHTENING_TYPE, "backward-pmnr" );
 
         NLR::NetworkLevelReasoner nlr;
         MockTableau tableau;
@@ -2021,7 +933,7 @@ public:
         TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( bounds ) );
         TS_ASSERT( boundsEqual( bounds, expectedBounds ) );
 
-        // Invoke PMNR with BBPS-based heuristic for neuron selection
+        // Invoke PMNR for neuron selection.
         TS_ASSERT_THROWS_NOTHING( updateTableau( tableau, bounds ) );
         TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
         TS_ASSERT_THROWS_NOTHING( nlr.lpRelaxationPropagation() );
@@ -2030,7 +942,7 @@ public:
             { Tightening( 9, -4.75, Tightening::LB ), Tightening( 9, 6.75, Tightening::UB ) } );
 
         TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( newBounds );
+        TS_ASSERT_THROWS_NOTHING( bounds = removeRedundancies( newBounds, bounds ) );
         TS_ASSERT( boundsEqual( bounds, expectedBounds2 ) );
 
         List<Map<NLR::NeuronIndex, unsigned>> infeasibleBranches( {} );
@@ -2039,11 +951,10 @@ public:
         TS_ASSERT( infeasibleBranchesEqual( infeasibleBranches, expectedInfeasibleBranches ) );
     }
 
-    void test_pmnr_bbps_leaky_relu_and_sigmoid()
+    void test_pmnr_leaky_relu_and_sigmoid()
     {
         Options::get()->setString( Options::SYMBOLIC_BOUND_TIGHTENING_TYPE, "sbt" );
-        Options::get()->setString( Options::MILP_SOLVER_BOUND_TIGHTENING_TYPE,
-                                   "backward-pmnr-bbps" );
+        Options::get()->setString( Options::MILP_SOLVER_BOUND_TIGHTENING_TYPE, "backward-pmnr" );
 
         NLR::NetworkLevelReasoner nlr;
         MockTableau tableau;
@@ -2082,7 +993,7 @@ public:
         TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( bounds ) );
         TS_ASSERT( boundsEqual( bounds, expectedBounds ) );
 
-        // Invoke PMNR with BBPS-based heuristic for neuron selection
+        // Invoke PMNR for neuron selection.
         TS_ASSERT_THROWS_NOTHING( updateTableau( tableau, bounds ) );
         TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
         TS_ASSERT_THROWS_NOTHING( nlr.lpRelaxationPropagation() );
@@ -2094,18 +1005,18 @@ public:
             Tightening( 8, 7.1, Tightening::UB ),
             Tightening( 9, -1.1, Tightening::LB ),
             Tightening( 9, 5.1, Tightening::UB ),
-            Tightening( 10, 0.0269, Tightening::LB ),
-            Tightening( 10, 0.9995, Tightening::UB ),
-            Tightening( 11, 0.1696, Tightening::LB ),
-            Tightening( 11, 0.9960, Tightening::UB ),
-            Tightening( 12, 0.0269, Tightening::LB ),
-            Tightening( 12, 0.9995, Tightening::UB ),
-            Tightening( 13, 0.5358, Tightening::LB ),
-            Tightening( 13, 3.9875, Tightening::UB ),
+            Tightening( 10, 0.1541, Tightening::LB ),
+            Tightening( 10, 0.9992, Tightening::UB ),
+            Tightening( 11, 0.2422, Tightening::LB ),
+            Tightening( 11, 0.9942, Tightening::UB ),
+            Tightening( 12, 0.1541, Tightening::LB ),
+            Tightening( 12, 0.9992, Tightening::UB ),
+            Tightening( 13, 0.8827, Tightening::LB ),
+            Tightening( 13, 3.9817, Tightening::UB ),
         } );
 
         TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( newBounds );
+        TS_ASSERT_THROWS_NOTHING( bounds = removeRedundancies( newBounds, bounds ) );
         TS_ASSERT( boundsEqual( bounds, expectedBounds2 ) );
 
         List<Map<NLR::NeuronIndex, unsigned>> infeasibleBranches( {} );
@@ -2114,11 +1025,10 @@ public:
         TS_ASSERT( infeasibleBranchesEqual( infeasibleBranches, expectedInfeasibleBranches ) );
     }
 
-    void test_pmnr_bbps_softmax_and_max()
+    void test_pmnr_softmax_and_max()
     {
         Options::get()->setString( Options::SYMBOLIC_BOUND_TIGHTENING_TYPE, "sbt" );
-        Options::get()->setString( Options::MILP_SOLVER_BOUND_TIGHTENING_TYPE,
-                                   "backward-pmnr-bbps" );
+        Options::get()->setString( Options::MILP_SOLVER_BOUND_TIGHTENING_TYPE, "backward-pmnr" );
 
         NLR::NetworkLevelReasoner nlr;
         MockTableau tableau;
@@ -2155,18 +1065,18 @@ public:
         TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( bounds ) );
         TS_ASSERT( boundsEqual( bounds, expectedBounds ) );
 
-        // Invoke PMNR with BBPS-based heuristic for neuron selection
+        // Invoke PMNR for neuron selection.
         TS_ASSERT_THROWS_NOTHING( updateTableau( tableau, bounds ) );
         TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
         TS_ASSERT_THROWS_NOTHING( nlr.lpRelaxationPropagation() );
 
         List<Tightening> expectedBounds2( {
             Tightening( 8, -0.6812, Tightening::LB ),
-            Tightening( 8, 1.8414, Tightening::UB ),
+            Tightening( 8, 1.6790, Tightening::UB ),
         } );
 
         TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( newBounds );
+        TS_ASSERT_THROWS_NOTHING( bounds = removeRedundancies( newBounds, bounds ) );
         TS_ASSERT( boundsEqual( bounds, expectedBounds2 ) );
 
         List<Map<NLR::NeuronIndex, unsigned>> infeasibleBranches( {} );
@@ -2175,11 +1085,10 @@ public:
         TS_ASSERT( infeasibleBranchesEqual( infeasibleBranches, expectedInfeasibleBranches ) );
     }
 
-    void test_pmnr_bbps_relu_and_bilinear()
+    void test_pmnr_relu_and_bilinear()
     {
         Options::get()->setString( Options::SYMBOLIC_BOUND_TIGHTENING_TYPE, "sbt" );
-        Options::get()->setString( Options::MILP_SOLVER_BOUND_TIGHTENING_TYPE,
-                                   "backward-pmnr-bbps" );
+        Options::get()->setString( Options::MILP_SOLVER_BOUND_TIGHTENING_TYPE, "backward-pmnr" );
 
         NLR::NetworkLevelReasoner nlr;
         MockTableau tableau;
@@ -2216,7 +1125,7 @@ public:
         TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( bounds ) );
         TS_ASSERT( boundsEqual( bounds, expectedBounds ) );
 
-        // Invoke PMNR with BBPS-based heuristic for neuron selection
+        // Invoke PMNR for neuron selection.
         TS_ASSERT_THROWS_NOTHING( updateTableau( tableau, bounds ) );
         TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
         TS_ASSERT_THROWS_NOTHING( nlr.lpRelaxationPropagation() );
@@ -2224,133 +1133,13 @@ public:
         List<Tightening> expectedBounds2( {} );
 
         TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( newBounds ) );
-        bounds = removeRedundancies( newBounds );
+        bounds = removeRedundancies( newBounds, bounds );
         TS_ASSERT( boundsEqual( bounds, expectedBounds2 ) );
 
         List<Map<NLR::NeuronIndex, unsigned>> infeasibleBranches( {} );
         List<Map<NLR::NeuronIndex, unsigned>> expectedInfeasibleBranches( {} );
         TS_ASSERT_THROWS_NOTHING( nlr.getInfeasibleBranches( infeasibleBranches ) );
         TS_ASSERT( infeasibleBranchesEqual( infeasibleBranches, expectedInfeasibleBranches ) );
-    }
-
-    void test_pmnr_bbps_relu()
-    {
-        Options::get()->setString( Options::SYMBOLIC_BOUND_TIGHTENING_TYPE, "sbt" );
-        Options::get()->setString( Options::MILP_SOLVER_BOUND_TIGHTENING_TYPE,
-                                   "backward-pmnr-bbps" );
-
-        NLR::NetworkLevelReasoner nlr;
-        MockTableau tableau;
-        nlr.setTableau( &tableau );
-        populateNetworkMinimalReLU( nlr, tableau );
-
-        tableau.setLowerBound( 0, -1 );
-        tableau.setUpperBound( 0, 1 );
-        tableau.setLowerBound( 1, -1 );
-        tableau.setUpperBound( 1, 1 );
-
-        // Invoke Parameterised DeepPoly
-        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
-        TS_ASSERT_THROWS_NOTHING( nlr.parameterisedDeepPoly() );
-
-        /*
-          Input ranges:
-
-          x0: [-1, 1]
-          x1: [-1, 1]
-
-          Layers 1, 2:
-
-          x2 = x0 + x1
-          x2.lb = x0 + x1   : [-2, 2]
-          x2.ub = x0 + x1   : [-2, 2]
-
-          x3 = x0 - x1
-          x3.lb = x0 - x1   : [-2, 2]
-          x3.ub = x0 - x1   : [-2, 2]
-
-          Both ReLUs are undecided, bounds are concretized. 2 = ub <= -lb = 2, using ReLU lower
-          coefficient of 0. Upper coefficient: 2/( 2--2 ) = 2/4 = 0.5
-
-          0 <= x4 <= 0.5x2 + 1
-          x4.lb = 0
-          x4.ub = 0.5 ( x0 + x1 ) + 1 = 0.5x0 + 0.5x1 + 1
-          x4 range: [0, 2]
-
-          0 <= x5 <= 0.5x3 + 1
-          x5.lb = 0
-          x5.ub = 0.5 ( x0 - x1 ) + 1 = 0.5x0 - 0.5x1 + 1
-          x5 range: [0, 2]
-
-          Layers 3, 4:
-
-          x6 = x4 + 2x5
-          x6.lb = 1 ( 0 ) + 2 ( 0 ) = 0   : [0, 0]
-          x6.ub = 1 ( 0.5x0 + 0.5x1 + 1 ) + 2 ( 0.5x0 - 0.5x1 + 1 ) = 1.5 x0 - 0.5 x1 + 3   : [1, 5]
-          x6 range: [0, 5]
-
-          x7 = x5 + 1.5
-          x7.lb = 1 ( 0 ) + 1.5 = 1.5   : [1.5, 1.5]
-          x7.ub = 1 ( 0.5x0 - 0.5x1 + 1 ) + 1.5 = 0.5x0 - 0.5x1 + 2.5  : [1.5, 3.5]
-          x7 range: [1.5, 3.5]
-
-          Both ReLU are active, bounds surive the activation
-
-          x6 <= x8 <= x6
-          x8.lb = 0
-          x8.ub = 1.5 x0 - 0.5 x1 + 3
-          x8 range: [0, 5]
-
-          x7 <= x9 <= x7
-          x9.lb = 1.5
-          x9.ub = 0.5x0 - 0.5x1 + 2.5
-          x9 range: [1.5, 3.5]
-
-          Layer 5:
-          x10 = - x8 + x9 + 1
-          x10.lb = -1 ( x6 ) + 1 ( x7 ) + 1 = -1 ( x4 + 2x5 ) + 1 ( x5 + 1.5 ) + 1 = -x4 - x5 + 2.5
-          >= - ( 0.5x2 + 1 ) - ( 0.5x3 + 1 ) + 2.5 = -0.5x2 - 0.5x3 + 0.5 = -x0 + 0.5 >= -0.5 :
-          [-0.5, -0.5] x10.ub = -1 ( x6 ) + 1 ( x7 ) + 1 = -1 ( x4 + 2x5 ) + 1 ( x5 + 1.5 ) + 2.5 =
-          -x4 - x5 + 2.5
-          <= - ( 0 ) - ( 0 ) + 2.5 = 2.5 : [2.5, 2.5]
-          x10 range: [-0.5, 2.5]
-
-        */
-
-        List<Tightening> expectedBounds( {
-            Tightening( 2, -2, Tightening::LB ),
-            Tightening( 2, 2, Tightening::UB ),
-            Tightening( 3, -2, Tightening::LB ),
-            Tightening( 3, 2, Tightening::UB ),
-            Tightening( 4, 0, Tightening::LB ),
-            Tightening( 4, 2, Tightening::UB ),
-            Tightening( 5, 0, Tightening::LB ),
-            Tightening( 5, 2, Tightening::UB ),
-            Tightening( 6, 0, Tightening::LB ),
-            Tightening( 6, 5, Tightening::UB ),
-            Tightening( 7, 1.5, Tightening::LB ),
-            Tightening( 7, 3.5, Tightening::UB ),
-            Tightening( 8, 0, Tightening::LB ),
-            Tightening( 8, 5, Tightening::UB ),
-            Tightening( 9, 1.5, Tightening::LB ),
-            Tightening( 9, 3.5, Tightening::UB ),
-            Tightening( 10, -0.5, Tightening::LB ),
-            Tightening( 10, 2.5, Tightening::UB ),
-        } );
-
-        List<Tightening> bounds;
-        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( bounds ) );
-        TS_ASSERT( boundsEqual( bounds, expectedBounds ) );
-
-        // Invoke PMNR with BBPS heuristic for neuron selection
-        TS_ASSERT_THROWS_NOTHING( updateTableau( tableau, bounds ) );
-        TS_ASSERT_THROWS_NOTHING( nlr.obtainCurrentBounds() );
-        TS_ASSERT_THROWS_NOTHING( nlr.lpRelaxationPropagation() );
-
-        List<Tightening> expectedBounds2( { Tightening( 10, 0.5000, Tightening::LB ) } );
-
-        TS_ASSERT_THROWS_NOTHING( nlr.getConstraintTightenings( bounds ) );
-        TS_ASSERT( boundsEqual( bounds, expectedBounds2 ) );
     }
 
     bool boundsEqual( const List<Tightening> &bounds, const List<Tightening> &expectedBounds )
@@ -2417,34 +1206,77 @@ public:
         return allFound;
     }
 
-    // Create list of all tightenings in newBounds for which there is no bound in newBounds which is
+    // Create list of all tightenings in bounds for which there is no bound which is
     // at least as tight.
-    List<Tightening> removeRedundancies( const List<Tightening> &newBounds )
+    List<Tightening> removeRedundancies( const List<Tightening> &bounds )
     {
         List<Tightening> minimalBounds;
-
         unsigned i = 0;
-        for ( const auto &newBound : newBounds )
+        for ( const auto &bound : bounds )
         {
             bool foundTighter = false;
             unsigned j = 0;
-            for ( const auto &bound : newBounds )
+            for ( const auto &otherBound : bounds )
             {
                 if ( i < j )
                 {
                     foundTighter |=
-                        ( newBound._type == bound._type && newBound._variable == bound._variable &&
-                          ( ( newBound._type == Tightening::LB &&
-                              FloatUtils::lte( newBound._value, bound._value, 0.0001 ) ) ||
-                            ( newBound._type == Tightening::UB &&
-                              FloatUtils::gte( newBound._value, bound._value, 0.0001 ) ) ) );
+                        ( bound._type == otherBound._type &&
+                          bound._variable == otherBound._variable &&
+                          ( ( bound._type == Tightening::LB &&
+                              FloatUtils::lte( bound._value, otherBound._value, 0.0001 ) ) ||
+                            ( bound._type == Tightening::UB &&
+                              FloatUtils::gte( bound._value, otherBound._value, 0.0001 ) ) ) );
                 }
                 ++j;
             }
-
             if ( !foundTighter )
-                minimalBounds.append( newBound );
+            {
+                minimalBounds.append( bound );
+            }
+            ++i;
+        }
+        return minimalBounds;
+    }
 
+    // Create list of all tightenings in bounds for which there is no bound in newBounds
+    // or in previousBounds which is at least as tight.
+    List<Tightening> removeRedundancies( const List<Tightening> &newBounds,
+                                         const List<Tightening> &bounds )
+    {
+        List<Tightening> minimalBounds;
+        unsigned i = 0;
+        for ( const auto &bound : newBounds )
+        {
+            bool foundTighter = false;
+            unsigned j = 0;
+            for ( const auto &otherBound : newBounds )
+            {
+                if ( i < j )
+                {
+                    foundTighter |=
+                        ( bound._type == otherBound._type &&
+                          bound._variable == otherBound._variable &&
+                          ( ( bound._type == Tightening::LB &&
+                              FloatUtils::lte( bound._value, otherBound._value, 0.0001 ) ) ||
+                            ( bound._type == Tightening::UB &&
+                              FloatUtils::gte( bound._value, otherBound._value, 0.0001 ) ) ) );
+                }
+                ++j;
+            }
+            for ( const auto &otherBound : bounds )
+            {
+                foundTighter |=
+                    ( bound._type == otherBound._type && bound._variable == otherBound._variable &&
+                      ( ( bound._type == Tightening::LB &&
+                          FloatUtils::lte( bound._value, otherBound._value, 0.0001 ) ) ||
+                        ( bound._type == Tightening::UB &&
+                          FloatUtils::gte( bound._value, otherBound._value, 0.0001 ) ) ) );
+            }
+            if ( !foundTighter )
+            {
+                minimalBounds.append( bound );
+            }
             ++i;
         }
         return minimalBounds;

--- a/src/proofs/SmtLibWriter.h
+++ b/src/proofs/SmtLibWriter.h
@@ -121,6 +121,7 @@ public:
       Returns a string representing the value of a double
      */
     static String signedValue( double val );
+
     /*
       A wrapper function calling all previous functions
     */


### PR DESCRIPTION
Manually Sync Fork + Results of PMNR Optimization Benchmarks: 1. BBPS heuristic final calculation modifed. 2. Alpha optimization removed from EXTENDED INVPROP. 3. PreimageApproximation is run before EXTENDED INVPROP. 4. BBPS branching candidates number increased to 100. 5. Removed milp-tightening options backward-invprop, backward-pmnr-random, backward-pmnr-gradient, renamed backward-pmnr-bbps to backward-pmnr. 6. Updated test files Test_PMNRSelection.h, Test_LPRelaxation.h, Test_PMNR.h.